### PR TITLE
feat: add eslint_d linter

### DIFF
--- a/lua/mason-registry/eslint_d/init.lua
+++ b/lua/mason-registry/eslint_d/init.lua
@@ -3,7 +3,7 @@ local npm = require "mason-core.managers.npm"
 
 return Pkg.new {
     name = "eslint_d",
-    desc = [[Eslint_d is a very fast eslint server for JavaScript and TypeScript]],
+    desc = [[Makes eslint the fastest linter on the planet]],
     homepage = "https://github.com/mantoni/eslint_d.js/",
     languages = { Pkg.Lang.TypeScript, Pkg.Lang.JavaScript },
     categories = { Pkg.Cat.Linter },

--- a/lua/mason-registry/eslint_d/init.lua
+++ b/lua/mason-registry/eslint_d/init.lua
@@ -1,0 +1,11 @@
+local Pkg = require "mason-core.package"
+local npm = require "mason-core.managers.npm"
+
+return Pkg.new {
+    name = "eslint_d",
+    desc = [[Eslint_d is a very fast eslint server for JavaScript and TypeScript]],
+    homepage = "https://github.com/mantoni/eslint_d.js/",
+    languages = { Pkg.Lang.TypeScript, Pkg.Lang.JavaScript },
+    categories = { Pkg.Cat.Linter },
+    install = npm.packages { "eslint_d", bin = { "eslint_d" } },
+}

--- a/lua/mason-registry/index.lua
+++ b/lua/mason-registry/index.lua
@@ -42,6 +42,7 @@ return {
   ["erlang-ls"] = "mason-registry.erlang-ls",
   esbonio = "mason-registry.esbonio",
   ["eslint-lsp"] = "mason-registry.eslint-lsp",
+  eslint_d = "mason-registry.eslint_d",
   ["firefox-debug-adapter"] = "mason-registry.firefox-debug-adapter",
   ["flux-lsp"] = "mason-registry.flux-lsp",
   ["foam-language-server"] = "mason-registry.foam-language-server",


### PR DESCRIPTION
This PR adds support for the eslint_d linter

its the recommended linter by null-ls for js/ts files because it creates a eslint server in the background to make linting much faster compared to just using the default eslint command for every save. (speeds up linting by 400+%)