### PR TITLE
feat(ui): bring focus to the installation section when :MasonInstall

### DIFF
--- a/lua/mason-core/ui/display.lua
+++ b/lua/mason-core/ui/display.lua
@@ -195,7 +195,7 @@ end
 ---@param filetype string
 function M.new_view_only_win(name, filetype)
     local namespace = vim.api.nvim_create_namespace(("installer_%s"):format(name))
-    local bufnr, renderer, mutate_state, get_state, unsubscribe, win_id, window_mgmt_augroup, autoclose_augroup, registered_keymaps, registered_keybinds, registered_effect_handlers
+    local bufnr, renderer, mutate_state, get_state, unsubscribe, win_id, window_mgmt_augroup, autoclose_augroup, registered_keymaps, registered_keybinds, registered_effect_handlers, sticky_cursor
     local has_initiated = false
     ---@type WindowOpts
     local window_opts = {}
@@ -261,7 +261,6 @@ function M.new_view_only_win(name, filetype)
             win_width = win_width,
         }
         local cursor_pos_pre_render = vim.api.nvim_win_get_cursor(win_id)
-        local sticky_cursor
         if output then
             sticky_cursor = output.sticky_cursors.line_map[cursor_pos_pre_render[1]]
         end
@@ -500,6 +499,17 @@ function M.new_view_only_win(name, filetype)
         get_cursor = function()
             assert(win_id ~= nil, "Window has not been opened, cannot get cursor.")
             return vim.api.nvim_win_get_cursor(win_id)
+        end,
+        ---@param tag any
+        set_sticky_cursor = function(tag)
+            if output then
+                local new_sticky_cursor_line = output.sticky_cursors.id_map[tag]
+                if new_sticky_cursor_line then
+                    sticky_cursor = tag
+                    local cursor = vim.api.nvim_win_get_cursor(win_id)
+                    vim.api.nvim_win_set_cursor(win_id, { new_sticky_cursor_line, cursor[2] })
+                end
+            end
         end,
     }
 end

--- a/lua/mason/api/command.lua
+++ b/lua/mason/api/command.lua
@@ -102,7 +102,11 @@ local function MasonInstall(package_specifiers)
     if is_headless then
         join_handles(handles)
     else
-        require("mason.ui").open()
+        local ui = require "mason.ui"
+        ui.open()
+        vim.schedule(function()
+            ui.set_sticky_cursor "installing-section"
+        end)
     end
 end
 

--- a/lua/mason/ui/components/main/package_list.lua
+++ b/lua/mason/ui/components/main/package_list.lua
@@ -190,7 +190,10 @@ local function Installing(state)
     local packages = state.packages.installing
     return PackageListContainer {
         state = state,
-        heading = Ui.HlTextNode(p.heading "Installing"),
+        heading = Ui.Node {
+            Ui.HlTextNode(p.heading "Installing"),
+            Ui.StickyCursor { id = "installing-section" },
+        },
         hide_when_empty = true,
         packages = packages,
         ---@param pkg Package

--- a/lua/mason/ui/init.lua
+++ b/lua/mason/ui/init.lua
@@ -8,9 +8,16 @@ function M.open()
     }
 end
 
+---@param view string
 function M.set_view(view)
     local api = require "mason.ui.instance"
     api.set_view(view)
+end
+
+---@param tag any
+function M.set_sticky_cursor(tag)
+    local api = require "mason.ui.instance"
+    api.set_sticky_cursor(tag)
 end
 
 return M

--- a/lua/mason/ui/instance.lua
+++ b/lua/mason/ui/instance.lua
@@ -609,7 +609,7 @@ return {
     set_view = function(view)
         set_view { payload = view }
     end,
-    set_sticky_cursor = function (tag)
+    set_sticky_cursor = function(tag)
         window.set_sticky_cursor(tag)
-    end
+    end,
 }

--- a/lua/mason/ui/instance.lua
+++ b/lua/mason/ui/instance.lua
@@ -609,4 +609,7 @@ return {
     set_view = function(view)
         set_view { payload = view }
     end,
+    set_sticky_cursor = function (tag)
+        window.set_sticky_cursor(tag)
+    end
 }


### PR DESCRIPTION
This ensures users see the progress output immediately, instead of
having to scroll down to see it.
