### PR TITLE
fix wrong configuration parameter

### DIFF
--- a/lua/mason-lspconfig/server_configurations/angularls/init.lua
+++ b/lua/mason-lspconfig/server_configurations/angularls/init.lua
@@ -2,8 +2,10 @@ local platform = require "mason-core.platform"
 local _ = require "mason-core.functional"
 local path = require "mason-core.path"
 
----@param install_dir string
-return function(install_dir)
+---@param config table
+return function(config)
+    local install_dir = config["install_dir"]
+
     local append_node_modules = _.map(function(dir)
         return path.concat { dir, "node_modules" }
     end)

--- a/lua/mason-lspconfig/server_configurations/apex_ls/init.lua
+++ b/lua/mason-lspconfig/server_configurations/apex_ls/init.lua
@@ -1,7 +1,9 @@
 local path = require "mason-core.path"
 
----@param install_dir string
-return function(install_dir)
+---@param config table
+return function(config)
+    local install_dir = config["install_dir"]
+
     return {
         apex_jar_path = path.concat { install_dir, "apex-jorje-lsp.jar" },
     }

--- a/lua/mason-lspconfig/server_configurations/julials/init.lua
+++ b/lua/mason-lspconfig/server_configurations/julials/init.lua
@@ -3,8 +3,10 @@ local platform = require "mason-core.platform"
 local fs = require "mason-core.fs"
 local _ = require "mason-core.functional"
 
----@param install_dir string
-return function(install_dir)
+---@param config table
+return function(config)
+    local install_dir = config["install_dir"]
+
     return {
         on_new_config = function(config, workspace_dir)
             local env_path = config.julia_env_path and vim.fn.expand(config.julia_env_path)

--- a/lua/mason-lspconfig/server_configurations/powershell_es/init.lua
+++ b/lua/mason-lspconfig/server_configurations/powershell_es/init.lua
@@ -1,5 +1,7 @@
----@param install_dir string
-return function(install_dir)
+---@param config table
+return function(config)
+    local install_dir = config["install_dir"]
+
     return {
         bundle_path = install_dir,
     }

--- a/lua/mason-lspconfig/server_configurations/pylsp/init.lua
+++ b/lua/mason-lspconfig/server_configurations/pylsp/init.lua
@@ -5,8 +5,10 @@ local process = require "mason-core.process"
 local notify = require "mason-core.notify"
 local spawn = require "mason-core.spawn"
 
----@param install_dir string
-return function(install_dir)
+---@param config table
+return function(config)
+    local install_dir = config["install_dir"]
+
     vim.api.nvim_create_user_command(
         "PylspInstall",
         a.scope(function(opts)

--- a/lua/mason-lspconfig/server_configurations/solang/init.lua
+++ b/lua/mason-lspconfig/server_configurations/solang/init.lua
@@ -1,8 +1,10 @@
 local path = require "mason-core.path"
 local process = require "mason-core.process"
 
----@param install_dir string
-return function(install_dir)
+---@param config table
+return function(config)
+    local install_dir = config["install_dir"]
+
     return {
         cmd_env = {
             PATH = process.extend_path {

--- a/lua/mason-lspconfig/server_configurations/volar/init.lua
+++ b/lua/mason-lspconfig/server_configurations/volar/init.lua
@@ -1,8 +1,10 @@
 local fs = require "mason-core.fs"
 local path = require "mason-core.path"
 
----@param install_dir string
-return function(install_dir)
+---@param config table
+return function(config)
+    local install_dir = config["install_dir"]
+
     ---@param dir string
     local function get_tsserverlib_path(dir)
         return path.concat { dir, "node_modules", "typescript", "lib", "tsserverlibrary.js" }


### PR DESCRIPTION
I found out that the type of parameter passed to the Volar configuration function is a table

<https://github.com/williamboman/mason.nvim/blob/f2a8cc435c6968dab63290491211cb74fdfe0c7d/lua/mason-lspconfig/init.lua#L75>

instead of a string. 

<https://github.com/williamboman/mason.nvim/blob/f2a8cc435c6968dab63290491211cb74fdfe0c7d/lua/mason-lspconfig/server_configurations/volar/init.lua#L4-L5>

The parameters required by this configuration function, `install_dir` of type string are placed in this table. This will cause some serious errors, such as Volar cannot find the `tsserverlibrary.js` it needs, and failing to start.

I fixed Volar in this PR now, but I think other LSP servers may also have this bug.