### PR TITLE
fix: correct package name for vint is vim-vint

### DIFF
--- a/lua/mason-registry/vint/init.lua
+++ b/lua/mason-registry/vint/init.lua
@@ -7,5 +7,5 @@ return Pkg.new {
     homepage = "https://github.com/Vimjas/vint",
     languages = { Pkg.Lang.VimScript },
     categories = { Pkg.Cat.Linter },
-    install = pip3.packages { "vint", bin = { "vint" } },
+    install = pip3.packages { "vim-vint", bin = { "vint" } },
 }


### PR DESCRIPTION
If you use the package name `vint` it appears to work but https://github.com/Vimjas/vint/issues/247 happens. Instead, use the package name `vim-vint`.