### PR TITLE
feat(ui): pass kind=mason-lang to vim.ui.select

### DIFF
--- a/lua/mason/ui/instance.lua
+++ b/lua/mason/ui/instance.lua
@@ -546,6 +546,7 @@ end
 local function filter()
     vim.ui.select(_.sort_by(_.identity, _.keys(Package.Lang)), {
         prompt = "Select language:",
+        kind = "mason-lang"
     }, function(choice)
         if not choice or choice == "" then
             return

--- a/lua/mason/ui/instance.lua
+++ b/lua/mason/ui/instance.lua
@@ -546,7 +546,7 @@ end
 local function filter()
     vim.ui.select(_.sort_by(_.identity, _.keys(Package.Lang)), {
         prompt = "Select language:",
-        kind = "mason.ui.language-filter"
+        kind = "mason.ui.language-filter",
     }, function(choice)
         if not choice or choice == "" then
             return

--- a/lua/mason/ui/instance.lua
+++ b/lua/mason/ui/instance.lua
@@ -546,7 +546,7 @@ end
 local function filter()
     vim.ui.select(_.sort_by(_.identity, _.keys(Package.Lang)), {
         prompt = "Select language:",
-        kind = "mason-lang"
+        kind = "mason.ui.language-filter"
     }, function(choice)
         if not choice or choice == "" then
             return


### PR DESCRIPTION
To allow styling it differently.

Example from neovim core: https://github.com/neovim/neovim/blob/7961f79904f6583ed3279fb1c73f2107ce9603ef/runtime/lua/vim/lsp/buf.lua#L807-L809