### PR TITLE
feat: add_package() for mason-registry

### DIFF
--- a/lua/mason-registry/init.lua
+++ b/lua/mason-registry/init.lua
@@ -59,6 +59,15 @@ function M.is_installed(package_name)
     return scan_install_root()[package_name] == true
 end
 
+-- Add a require path to the index
+-- @param package_name string
+-- @param module_path string
+function M.add_package(package_name, module_path)
+	if not index[package_name] then
+		index[package_name] = module_path
+	end
+end
+
 ---Returns an instance of the Package class if the provided package name exists. This function errors if a package cannot be found.
 ---@param package_name string
 ---@return Package

--- a/lua/mason-registry/init.lua
+++ b/lua/mason-registry/init.lua
@@ -63,9 +63,9 @@ end
 -- @param package_name string
 -- @param module_path string
 function M.add_package(package_name, module_path)
-	if not index[package_name] then
-		index[package_name] = module_path
-	end
+    if not index[package_name] then
+        index[package_name] = module_path
+    end
 end
 
 ---Returns an instance of the Package class if the provided package name exists. This function errors if a package cannot be found.


### PR DESCRIPTION
In testing some new package additions to the registry, I found it frustrating that unless a package is added to `mason-registry.index`, things like `Package:is_installed()` don't seem to work. This adds a function to `mason-registry` that extends `mason-registry.index` and allows for locally authored packages to work as intended with `mason`.

Ideally, I'd like to be able to add a PackageSpec to index, but given the way index works, this seemed like the easiest solution for the moment.