### PR TITLE
fix(ui): don't call terminate handler when setting up handle

### DIFF
--- a/lua/mason-core/ui/display.lua
+++ b/lua/mason-core/ui/display.lua
@@ -245,8 +245,6 @@ function M.new_view_only_win(name, filetype)
     local draw = function(view)
         local win_valid = win_id ~= nil and vim.api.nvim_win_is_valid(win_id)
         local buf_valid = bufnr ~= nil and vim.api.nvim_buf_is_valid(bufnr)
-        log.fmt_trace("got bufnr=%s", bufnr)
-        log.fmt_trace("got win_id=%s", win_id)
 
         if not win_valid or not buf_valid then
             -- the window has been closed or the buffer is somehow no longer valid

--- a/lua/mason/ui/instance.lua
+++ b/lua/mason/ui/instance.lua
@@ -178,11 +178,10 @@ end
 
 ---@param handle InstallHandle
 local function setup_handle(handle)
-    ---@param new_state InstallHandleState
-    local function handle_state_change(new_state)
-        if new_state == "QUEUED" then
+    local function handle_state_change()
+        if handle.state == "QUEUED" then
             mutate_package_grouping(handle.package, "queued", true)
-        elseif new_state == "ACTIVE" then
+        elseif handle.state == "ACTIVE" then
             mutate_package_grouping(handle.package, "installing", true)
         end
     end
@@ -234,8 +233,7 @@ local function setup_handle(handle)
     handle:on("stderr", handle_output)
 
     -- hydrate initial state
-    handle_state_change(handle.state)
-    handle_terminate()
+    handle_state_change()
     handle_spawnhandle_change()
     mutate_state(function(state)
         state.packages.states[handle.package.name].tailed_output = {}


### PR DESCRIPTION
The terminate handler should only really be called when the handle is
terminated. By calling it immediately (to initialize UI state), any
queued packages would be reset to either the "installed" or
"uninstalled" group, when they really should remain "queued".
