### PR TITLE
feat(taplo): use prebuilt binary if available

### DIFF
--- a/lua/mason-registry/taplo/init.lua
+++ b/lua/mason-registry/taplo/init.lua
@@ -1,5 +1,10 @@
 local Pkg = require "mason-core.package"
 local cargo = require "mason-core.managers.cargo"
+local github = require "mason-core.managers.github"
+local _ = require "mason-core.functional"
+local platform = require "mason-core.platform"
+
+local coalesce, when = _.coalesce, _.when
 
 return Pkg.new {
     name = "taplo",
@@ -7,8 +12,26 @@ return Pkg.new {
     homepage = "https://taplo.tamasfe.dev/",
     languages = { Pkg.Lang.TOML },
     categories = { Pkg.Cat.LSP },
-    install = cargo.crate("taplo-cli", {
-        features = "lsp",
-        bin = { "taplo" },
-    }),
+    ---@async
+    ---@param ctx InstallContext
+    install = function(ctx)
+        local asset_file = coalesce(
+            when(platform.is.mac, "taplo-full-x86_64-apple-darwin-gnu.tar.gz"),
+            when(platform.is.linux_x64, "taplo-full-x86_64-unknown-linux-gnu.tar.gz")
+        )
+        if asset_file then
+            github
+                .untargz_release_file({
+                    repo = "tamasfe/taplo",
+                    asset_file = asset_file,
+                })
+                .with_receipt()
+            ctx:link_bin("taplo", "taplo")
+        else
+            cargo.crate("taplo-cli", {
+                features = "lsp",
+                bin = { "taplo" },
+            })
+        end
+    end,
 }

--- a/lua/mason-registry/taplo/init.lua
+++ b/lua/mason-registry/taplo/init.lua
@@ -29,7 +29,7 @@ return Pkg.new {
             ctx:link_bin("taplo", "taplo")
         else
             cargo.crate("taplo-cli", {
-                features = "lsp",
+                features = "lsp,toml-test",
                 bin = { "taplo" },
             })
         end


### PR DESCRIPTION
I don't like this kind of mixing of installation sources, but I figured
this could be a good first experiment.
