### PR TITLE
Add default option to highlights

### DIFF
--- a/lua/mason/ui/palette.lua
+++ b/lua/mason/ui/palette.lua
@@ -1,26 +1,26 @@
 local M = {}
 
 M.highlight_groups = {
-    MasonHeader = { bold = true, fg = "#222222", bg = "#DCA561" },
-    MasonHeaderSecondary = { bold = true, fg = "#222222", bg = "#56B6C2" },
+    MasonHeader = { bold = true, fg = "#222222", bg = "#DCA561", default = true },
+    MasonHeaderSecondary = { bold = true, fg = "#222222", bg = "#56B6C2", default = true },
 
-    MasonHighlight = { fg = "#56B6C2" },
-    MasonHighlightBlock = { bg = "#56B6C2", fg = "#222222" },
-    MasonHighlightBlockBold = { bg = "#56B6C2", fg = "#222222", bold = true },
+    MasonHighlight = { fg = "#56B6C2", default = true },
+    MasonHighlightBlock = { bg = "#56B6C2", fg = "#222222", default = true },
+    MasonHighlightBlockBold = { bg = "#56B6C2", fg = "#222222", bold = true, default = true },
 
-    MasonHighlightSecondary = { fg = "#DCA561" },
-    MasonHighlightBlockSecondary = { bg = "#DCA561", fg = "#222222" },
-    MasonHighlightBlockBoldSecondary = { bg = "#DCA561", fg = "#222222", bold = true },
+    MasonHighlightSecondary = { fg = "#DCA561", default = true },
+    MasonHighlightBlockSecondary = { bg = "#DCA561", fg = "#222222", default = true },
+    MasonHighlightBlockBoldSecondary = { bg = "#DCA561", fg = "#222222", bold = true, default = true },
 
-    MasonLink = { link = "MasonHighlight" },
+    MasonLink = { link = "MasonHighlight", default = true },
 
-    MasonMuted = { fg = "#888888" },
-    MasonMutedBlock = { bg = "#888888", fg = "#222222" },
-    MasonMutedBlockBold = { bg = "#888888", fg = "#222222", bold = true },
+    MasonMuted = { fg = "#888888", default = true },
+    MasonMutedBlock = { bg = "#888888", fg = "#222222", default = true },
+    MasonMutedBlockBold = { bg = "#888888", fg = "#222222", bold = true, default = true },
 
-    MasonError = { fg = "#f44747" },
+    MasonError = { fg = "#f44747", default = true },
 
-    MasonHeading = { bold = true },
+    MasonHeading = { bold = true, default = true },
 }
 
 local function hl(highlight)


### PR DESCRIPTION
This avoids overriding user-provided highlight group definitions.
Discussed in #133.

https://neovim.io/doc/user/syntax.html#:hi-default