### PR TITLE
fix(selene): download error in Windows

### DIFF
--- a/lua/mason-registry/selene/init.lua
+++ b/lua/mason-registry/selene/init.lua
@@ -22,7 +22,7 @@ return Pkg.new {
                     local target = coalesce(
                         when(platform.is.mac, "selene-%s-macos.zip"),
                         when(platform.is.linux_x64, "selene-%s-linux.zip"),
-                        when(platform.is.win_x64, "selene-%s-win64.zip")
+                        when(platform.is.win_x64, "selene-%s-windows.zip")
                     )
                     return target and target:format(release)
                 end,


### PR DESCRIPTION
The filename should be `selene-%s-windows.zip` instead of `selene-%s-win64.zip`.