### PR TITLE
fix(taplo): write receipt when installing via cargo

### DIFF
--- a/lua/mason-registry/taplo/init.lua
+++ b/lua/mason-registry/taplo/init.lua
@@ -28,10 +28,12 @@ return Pkg.new {
                 .with_receipt()
             ctx:link_bin("taplo", "taplo")
         else
-            cargo.crate("taplo-cli", {
-                features = "lsp,toml-test",
-                bin = { "taplo" },
-            })
+            cargo
+                .install("taplo-cli", {
+                    features = "lsp,toml-test",
+                    bin = { "taplo" },
+                })
+                .with_receipt()
         end
     end,
 }


### PR DESCRIPTION
Fixes #236.
