### PR TITLE
feat(api): add MasonInstallComplete autocmd event

### DIFF
--- a/lua/mason-core/package/init.lua
+++ b/lua/mason-core/package/init.lua
@@ -108,6 +108,12 @@ function Package:install(opts)
                 ---@param success boolean
                 ---@param result Result
                 function(success, result)
+                    vim.schedule(function()
+                        vim.api.nvim_exec_autocmds("User", {
+                            pattern = "MasonInstallComplete",
+                            data = { name = self.name, success = success, results = result },
+                        })
+                    end)
                     if not success then
                         log.error("Unexpected error", result)
                         self:emit("install:failed", handle)


### PR DESCRIPTION
## Description

add an autocmd-event that will trigger when the installer is done

the callback takes `{name: string, success: boolean, result: table }`

example usage:

```lua
vim.api.nvim_create_autocmd("User", {
  pattern = "MasonInstallComplete",
  callback = function(args)
    vim.notify("MasonInstallComplete was called!, got: " .. vim.inspect(args.data))
  end,
})
```

semi-related: https://github.com/williamboman/mason.nvim/issues/169
