### PR TITLE
debugpy load module `debugpy.adapter` instead of `debugpy`

### DIFF
--- a/lua/mason-core/installer/context.lua
+++ b/lua/mason-core/installer/context.lua
@@ -217,7 +217,7 @@ end
 function InstallContext:write_pyvenv_exec_wrapper(new_executable_rel_path, module)
     return self:write_shell_exec_wrapper(
         new_executable_rel_path,
-        ("%q -m %s.adapter"):format(
+        ("%q -m %s"):format(
             path.concat {
                 require("mason-core.managers.pip3").venv_path(self.package:get_install_path()),
                 "python",

--- a/lua/mason-core/installer/context.lua
+++ b/lua/mason-core/installer/context.lua
@@ -217,7 +217,7 @@ end
 function InstallContext:write_pyvenv_exec_wrapper(new_executable_rel_path, module)
     return self:write_shell_exec_wrapper(
         new_executable_rel_path,
-        ("%q -m %s"):format(
+        ("%q -m %s.adapter"):format(
             path.concat {
                 require("mason-core.managers.pip3").venv_path(self.package:get_install_path()),
                 "python",

--- a/lua/mason-registry/debugpy/init.lua
+++ b/lua/mason-registry/debugpy/init.lua
@@ -12,6 +12,7 @@ return Pkg.new {
     ---@param ctx InstallContext
     install = function(ctx)
         pip3.install({ "debugpy" }).with_receipt()
-        ctx:link_bin("debugpy", ctx:write_pyvenv_exec_wrapper("debugpy", "debugpy.adapter"))
+        ctx:link_bin("debugpy", ctx:write_pyvenv_exec_wrapper("debugpy", "debugpy"))
+        ctx:link_bin("debugpy-adapter", ctx:write_pyvenv_exec_wrapper("debugpy-adapter", "debugpy.adapter"))
     end,
 }

--- a/lua/mason-registry/debugpy/init.lua
+++ b/lua/mason-registry/debugpy/init.lua
@@ -12,6 +12,6 @@ return Pkg.new {
     ---@param ctx InstallContext
     install = function(ctx)
         pip3.install({ "debugpy" }).with_receipt()
-        ctx:link_bin("debugpy", ctx:write_pyvenv_exec_wrapper("debugpy", "debugpy"))
+        ctx:link_bin("debugpy", ctx:write_pyvenv_exec_wrapper("debugpy", "debugpy.adapter"))
     end,
 }


### PR DESCRIPTION
In the example https://github.com/mfussenegger/nvim-dap/wiki/Debug-Adapter-installation#python, we load module `debugpy.adapter` not `debugpy`