### PR TITLE
docs: change to a more appropriate word

### DIFF
--- a/doc/mason.txt
+++ b/doc/mason.txt
@@ -58,7 +58,7 @@ To view the UI for mason, run:
 Install a package via `:MasonInstall`, for example:
     :MasonInstall stylua
 
-You may also install multiple languages at a time:
+You may also install multiple packages at a time:
     :MasonInstall stylua lua-language-server
 
 To install a specific version of a package, you may provide it as part of the


### PR DESCRIPTION
In this case, using `packages` instead of `languages` makes more sense.
In the example given, we're not installing just "languages" but also
other packages (a formatter)