### PR TITLE
don't download x64 taplo binary for arm64 mac

### DIFF
--- a/lua/mason-registry/taplo/init.lua
+++ b/lua/mason-registry/taplo/init.lua
@@ -16,7 +16,7 @@ return Pkg.new {
     ---@param ctx InstallContext
     install = function(ctx)
         local asset_file = coalesce(
-            when(platform.is.mac, "taplo-full-x86_64-apple-darwin-gnu.tar.gz"),
+            when(platform.is.mac_x64, "taplo-full-x86_64-apple-darwin-gnu.tar.gz"),
             when(platform.is.linux_x64, "taplo-full-x86_64-unknown-linux-gnu.tar.gz")
         )
         if asset_file then


### PR DESCRIPTION
`taplo` only provides a x64 pre-compiled binary for mac, so it would be better to use cargo to install taplo on arm64 mac.