### PR TITLE
fix(omnisharp-mono): don't link directly to the `run` script

### DIFF
--- a/lua/mason-registry/omnisharp-mono/init.lua
+++ b/lua/mason-registry/omnisharp-mono/init.lua
@@ -29,7 +29,7 @@ return Pkg.new {
                         ),
                     })
                     .with_receipt()
-                ctx:link_bin("omnisharp-mono", "run")
+                ctx:link_bin("omnisharp-mono", ctx:write_exec_wrapper("omnisharp-mono", "run"))
             end,
             win = function()
                 github


### PR DESCRIPTION
This `run` script can only be executed from its installation location
(i.e. symlink = bad).
