### PR TITLE
fix(ui): use `g?` to toggle help instead of `?`

### DIFF
--- a/lua/mason/ui/components/header.lua
+++ b/lua/mason/ui/components/header.lua
@@ -13,8 +13,8 @@ return function(state)
             }),
             Ui.When(
                 state.view.is_showing_help,
-                { p.none "        press ", p.highlight_secondary "?", p.none " for package list" },
-                { p.none "press ", p.highlight "?", p.none " for help" }
+                { p.none "        press ", p.highlight_secondary "g?", p.none " for package list" },
+                { p.none "press ", p.highlight "g?", p.none " for help" }
             ),
             { p.Comment "https://github.com/williamboman/mason.nvim" },
         },

--- a/lua/mason/ui/instance.lua
+++ b/lua/mason/ui/instance.lua
@@ -21,7 +21,7 @@ local Semaphore = control.Semaphore
 ---@param state InstallerUiState
 local function GlobalKeybinds(state)
     return Ui.Node {
-        Ui.Keybind("?", "TOGGLE_HELP", nil, true),
+        Ui.Keybind("g?", "TOGGLE_HELP", nil, true),
         Ui.Keybind("q", "CLOSE_WINDOW", nil, true),
         Ui.When(not state.view.language_filter, Ui.Keybind("<Esc>", "CLOSE_WINDOW", nil, true)),
         Ui.When(state.view.language_filter, Ui.Keybind("<Esc>", "CLEAR_LANGUAGE_FILTER", nil, true)),


### PR DESCRIPTION
The `?` keymap has annoyed me personally for a long time. I don't like
overriding backwards search, it's far more useful than toggling the help
view.
