### PR TITLE
fixes help menu mapping mismatch

### DIFF
--- a/lua/mason/ui/components/help/init.lua
+++ b/lua/mason/ui/components/help/init.lua
@@ -47,7 +47,7 @@ end
 ---@param state InstallerUiState
 local function GenericHelp(state)
     local keymap_tuples = {
-        { "Toggle help", "?" },
+        { "Toggle help", "g?" },
         { "Toggle package info", settings.current.ui.keymaps.toggle_package_expand },
         { "Apply language filter", settings.current.ui.keymaps.apply_language_filter },
         { "Install package", settings.current.ui.keymaps.install_package },


### PR DESCRIPTION
![Screenshot 2022-08-24 at 20 03 37](https://user-images.githubusercontent.com/57884511/186415849-1f5ed6fb-3788-4b67-97a1-2e87e1d629f2.png)

Help menu mapping did not change in https://github.com/williamboman/mason.nvim/pull/326