### PR TITLE
feat: adding `solhint` linter for Solidity code

### DIFF
--- a/lua/mason-registry/index.lua
+++ b/lua/mason-registry/index.lua
@@ -161,6 +161,7 @@ return {
   ["slint-lsp"] = "mason-registry.slint-lsp",
   solang = "mason-registry.solang",
   solargraph = "mason-registry.solargraph",
+  solhint = "mason-registry.solhint",
   solidity = "mason-registry.solidity",
   sorbet = "mason-registry.sorbet",
   sourcery = "mason-registry.sourcery",
@@ -205,3 +206,4 @@ return {
   zk = "mason-registry.zk",
   zls = "mason-registry.zls"
 }
+

--- a/lua/mason-registry/index.lua
+++ b/lua/mason-registry/index.lua
@@ -206,4 +206,3 @@ return {
   zk = "mason-registry.zk",
   zls = "mason-registry.zls"
 }
-

--- a/lua/mason-registry/solhint/init.lua
+++ b/lua/mason-registry/solhint/init.lua
@@ -1,0 +1,11 @@
+local Pkg = require "mason-core.package"
+local npm = require "mason-core.managers.npm"
+
+return Pkg.new {
+  name = "solhint",
+  desc = [[Solhint is a linting utility for Solidity code]],
+  homepage = "https://protofire.github.io/solhint/",
+  languages = { Pkg.Lang.Solidity },
+  categories = { Pkg.Cat.Linter },
+  install = npm.packages { "solhint", bin = { "solhint" } },
+}

--- a/lua/mason/mappings/language.lua
+++ b/lua/mason/mappings/language.lua
@@ -94,7 +94,7 @@ return {
   scss = { "css-lsp", "prettier", "prettierd" },
   shell = { "shfmt" },
   slint = { "slint-lsp" },
-  solidity = { "solang", "solidity" },
+  solidity = { "solang", "solhint", "solidity" },
   sphinx = { "esbonio" },
   sql = { "sql-formatter", "sqlfluff", "sqlls", "sqls" },
   stylelint = { "stylelint-lsp" },


### PR DESCRIPTION
Requesting to add the [solhint](https://protofire.github.io/solhint/) linter to mason. This allows linting of [solidity](https://soliditylang.org/) files which can be handled by [null-ls](https://github.com/jose-elias-alvarez/null-ls.nvim/blob/main/doc/BUILTINS.md#solhintl).

Thank you 🙏🏾 