### PR TITLE
feat: add `solidity-language-server` LSP

### DIFF
--- a/lua/mason-registry/index.lua
+++ b/lua/mason-registry/index.lua
@@ -163,6 +163,7 @@ return {
   solargraph = "mason-registry.solargraph",
   solhint = "mason-registry.solhint",
   solidity = "mason-registry.solidity",
+  ["solidity-language-server"] = "mason-registry.solidity-language-server",
   sorbet = "mason-registry.sorbet",
   sourcery = "mason-registry.sourcery",
   ["spectral-language-server"] = "mason-registry.spectral-language-server",

--- a/lua/mason-registry/solidity-language-server/init.lua
+++ b/lua/mason-registry/solidity-language-server/init.lua
@@ -7,5 +7,5 @@ return Pkg.new {
     homepage = "https://www.npmjs.com/package/solidity-language-server",
     languages = { Pkg.Lang.Solidity },
     categories = { Pkg.Cat.LSP },
-    install = npm.packages { "solidity-language-server", "graphql", bin = { "solidity-language-server" } },
+    install = npm.packages { "solidity-language-server", bin = { "solidity-language-server" } },
 }

--- a/lua/mason-registry/solidity-language-server/init.lua
+++ b/lua/mason-registry/solidity-language-server/init.lua
@@ -1,0 +1,11 @@
+local Pkg = require "mason-core.package"
+local npm = require "mason-core.managers.npm"
+
+return Pkg.new {
+    name = "solidity-language-server",
+    desc = [[Solidity language server provides support for autocompletion, snippets, and syntax highlghting on solidity files]],
+    homepage = "https://www.npmjs.com/package/solidity-language-server",
+    languages = { Pkg.Lang.Solidity },
+    categories = { Pkg.Cat.LSP },
+    install = npm.packages { "solidity-language-server", "graphql", bin = { "solidity-language-server" } },
+}

--- a/lua/mason/mappings/language.lua
+++ b/lua/mason/mappings/language.lua
@@ -94,7 +94,7 @@ return {
   scss = { "css-lsp", "prettier", "prettierd" },
   shell = { "shfmt" },
   slint = { "slint-lsp" },
-  solidity = { "solang", "solhint", "solidity" },
+  solidity = { "solang", "solhint", "solidity", "solidity-language-server" },
   sphinx = { "esbonio" },
   sql = { "sql-formatter", "sqlfluff", "sqlls", "sqls" },
   stylelint = { "stylelint-lsp" },


### PR DESCRIPTION
Adding support for a more fully featured [Solidity LSP](https://www.npmjs.com/package/solidity-language-server) (as compared to the official release from the `solc` compiler). This can be [enabled in lsp-config](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#solidity_ls) as `solidity_ls`.

Thank you 🙏🏾 