### PR TITLE
Bugfix for the fantomas binany name

### DIFF
--- a/lua/mason-registry/fantomas/init.lua
+++ b/lua/mason-registry/fantomas/init.lua
@@ -7,5 +7,5 @@ return Pkg.new {
     homepage = "https://fsprojects.github.io/fantomas",
     languages = { Pkg.Lang["F#"] },
     categories = { Pkg.Cat.Formatter },
-    install = dotnet.package("fantomas", { bin = { "dotnet-fantomas" } }),
+    install = dotnet.package("fantomas", { bin = { "fantomas" } }),
 }


### PR DESCRIPTION
Bugfix for the fantomas binary name.

Tested with `:MasonInstall fantomas@5.0.0-beta-009`