### PR TITLE
fix(clojure-lsp): use the static release of clojure-lsp when running on musl libc

### DIFF
--- a/lua/mason-registry/clojure-lsp/init.lua
+++ b/lua/mason-registry/clojure-lsp/init.lua
@@ -21,6 +21,7 @@ return Pkg.new {
                 asset_file = coalesce(
                     when(platform.is.mac_arm64, "clojure-lsp-native-macos-aarch64.zip"),
                     when(platform.is.mac_x64, "clojure-lsp-native-macos-amd64.zip"),
+                    when(platform.is_linux and platform.get_libc() == "musl", "clojure-lsp-native-static-linux-amd64.zip"),
                     when(platform.is.linux_x64, "clojure-lsp-native-linux-amd64.zip"),
                     when(platform.is.linux_arm64, "clojure-lsp-native-linux-aarch64.zip"),
                     when(platform.is_win, "clojure-lsp-native-windows-amd64.zip")

--- a/lua/mason-registry/clojure-lsp/init.lua
+++ b/lua/mason-registry/clojure-lsp/init.lua
@@ -21,7 +21,10 @@ return Pkg.new {
                 asset_file = coalesce(
                     when(platform.is.mac_arm64, "clojure-lsp-native-macos-aarch64.zip"),
                     when(platform.is.mac_x64, "clojure-lsp-native-macos-amd64.zip"),
-                    when(platform.is_linux and platform.get_libc() == "musl", "clojure-lsp-native-static-linux-amd64.zip"),
+                    when(
+                        platform.is_linux and platform.get_libc() == "musl",
+                        "clojure-lsp-native-static-linux-amd64.zip"
+                    ),
                     when(platform.is.linux_x64, "clojure-lsp-native-linux-amd64.zip"),
                     when(platform.is.linux_arm64, "clojure-lsp-native-linux-aarch64.zip"),
                     when(platform.is_win, "clojure-lsp-native-windows-amd64.zip")

--- a/lua/mason-registry/clojure-lsp/init.lua
+++ b/lua/mason-registry/clojure-lsp/init.lua
@@ -22,10 +22,10 @@ return Pkg.new {
                     when(platform.is.mac_arm64, "clojure-lsp-native-macos-aarch64.zip"),
                     when(platform.is.mac_x64, "clojure-lsp-native-macos-amd64.zip"),
                     when(
-                        platform.is_linux and platform.get_libc() == "musl",
+                        platform.is.linux_x64 and platform.get_libc() == "musl",
                         "clojure-lsp-native-static-linux-amd64.zip"
                     ),
-                    when(platform.is.linux_x64, "clojure-lsp-native-linux-amd64.zip"),
+                    when(platform.is.linux_x64 and platform.get_libc() == "glibc", "clojure-lsp-native-linux-amd64.zip"),
                     when(platform.is.linux_arm64, "clojure-lsp-native-linux-aarch64.zip"),
                     when(platform.is_win, "clojure-lsp-native-windows-amd64.zip")
                 ),


### PR DESCRIPTION
This allows clojure-lsp installed with mason to work on musl based distros like Alpine.

For reference, the clojure-lsp commit that introduced musl to static builds: https://github.com/clojure-lsp/clojure-lsp/commit/a76653e221b568336c0b99fcc3763c0c2b7ef4ec