### PR TITLE
fix(spectral-language-server): build directly from source

### DIFF
--- a/lua/mason-core/managers/github/init.lua
+++ b/lua/mason-core/managers/github/init.lua
@@ -18,7 +18,6 @@ local M = {}
 ---@param asset_file string
 ---@param release string
 local function with_release_file_receipt(repo, asset_file, release)
-    ---@return InstallReceiptGitHubReleaseFileSource
     return function()
         local ctx = installer.context()
         ctx.receipt:with_primary_source {

--- a/lua/mason-registry/spectral-language-server/init.lua
+++ b/lua/mason-registry/spectral-language-server/init.lua
@@ -1,6 +1,9 @@
 local Pkg = require "mason-core.package"
-local npm = require "mason-core.managers.npm"
+local git = require "mason-core.managers.git"
+local github = require "mason-core.managers.github"
 local _ = require "mason-core.functional"
+local Optional = require "mason-core.optional"
+local path = require "mason-core.path"
 
 return Pkg.new {
     name = "spectral-language-server",
@@ -11,5 +14,19 @@ return Pkg.new {
     homepage = "https://github.com/luizcorreia/spectral-language-server",
     languages = { Pkg.Lang.JSON, Pkg.Lang.YAML },
     categories = { Pkg.Cat.LSP },
-    install = npm.packages { "spectral-language-server", bin = { "spectral-language-server" } },
+    ---@async
+    ---@param ctx InstallContext
+    install = function(ctx)
+        local source = github.tag { repo = "stoplightio/vscode-spectral" }
+        source.with_receipt()
+        ctx.fs:mkdir "build"
+        ctx:chdir("build", function()
+            git.clone { "https://github.com/stoplightio/vscode-spectral", version = Optional.of(source.tag) }
+            ctx.spawn.npm { "install" }
+            ctx.spawn.node { "make", "package" }
+        end)
+        ctx.fs:rename(path.concat { "build", "dist", "server", "index.js" }, "spectral-language-server.js")
+        ctx.fs:rmrf "build"
+        ctx:write_node_exec_wrapper("spectral-language-server", "spectral-language-server.js")
+    end,
 }


### PR DESCRIPTION
The npm package is an unofficial one, and it seems to be relying on a
build script (broken) to execute during installation, instead of pre-packaging
it.

Fixes #463.
