### PR TITLE
fix(stylua): cannot be installed on arm64 Linux

### DIFF
--- a/lua/mason-registry/stylua/init.lua
+++ b/lua/mason-registry/stylua/init.lua
@@ -20,7 +20,8 @@ return Pkg.new {
                 asset_file = coalesce(
                     when(platform.is.mac_arm64, "stylua-macos-aarch64.zip"),
                     when(platform.is.mac_x64, "stylua-macos.zip"),
-                    when(platform.is.linux_x64, "stylua-linux.zip"),
+                    when(platform.is.linux_x64, "stylua-linux-x86_64.zip"),
+                    when(platform.is.linux_arm64, "stylua-linux-aarch64.zip"),
                     when(platform.is.win_x64, "stylua-win64.zip")
                 ),
             })


### PR DESCRIPTION
This is because I'm using Neovim in Ubuntu that runs on Docker which runs on Apple M1 MacBook.