### PR TITLE
feat: java-debug-adapter, java-test

### DIFF
--- a/lua/mason-registry/index.lua
+++ b/lua/mason-registry/index.lua
@@ -97,6 +97,8 @@ return {
   impl = "mason-registry.impl",
   intelephense = "mason-registry.intelephense",
   isort = "mason-registry.isort",
+  ["java-debug-adapter"] = "mason-registry.java-debug-adapter",
+  ["java-test"] = "mason-registry.java-test",
   jdtls = "mason-registry.jdtls",
   ["jedi-language-server"] = "mason-registry.jedi-language-server",
   joker = "mason-registry.joker",

--- a/lua/mason-registry/java-debug-adapter/init.lua
+++ b/lua/mason-registry/java-debug-adapter/init.lua
@@ -15,7 +15,7 @@ return Pkg.new {
         github
             .unzip_release_file({
                 repo = "microsoft/vscode-java-debug",
-                asset_file = _.compose(_.format "vscjava.vscode-java-debug-%s.vsix", _.gsub("^v", "")),
+                asset_file = _.format "vscjava.vscode-java-debug-%s.vsix",
             })
             .with_receipt()
 

--- a/lua/mason-registry/java-debug-adapter/init.lua
+++ b/lua/mason-registry/java-debug-adapter/init.lua
@@ -7,11 +7,8 @@ local Optional = require "mason-core.optional"
 
 return Pkg.new {
     name = "java-debug-adapter",
-    desc = _.dedent [[
-        Java Debug Server for Visual Studio Code
-        The Java Debug Server is an implementation of Visual Studio Code (VSCode) Debug Protocol.
-    ]],
-    homepage = "https://github.com/microsoft/vscode-java-debug",
+    desc = [[The debug server implementation for Java. It conforms to the debugger adapter protocol.]],
+    homepage = "https://github.com/microsoft/java-debug",
     languages = { Pkg.Lang.Java },
     categories = { Pkg.Cat.DAP },
     ---@async

--- a/lua/mason-registry/java-debug-adapter/init.lua
+++ b/lua/mason-registry/java-debug-adapter/init.lua
@@ -1,0 +1,56 @@
+local Pkg = require "mason-core.package"
+local github = require "mason-core.managers.github"
+local github_client = require "mason-core.managers.github.client"
+local _ = require "mason-core.functional"
+local path = require "mason-core.path"
+local Optional = require "mason-core.optional"
+
+return Pkg.new {
+    name = "java-debug-adapter",
+    desc = _.dedent [[
+        Java Debug Server for Visual Studio Code
+        The Java Debug Server is an implementation of Visual Studio Code (VSCode) Debug Protocol.
+    ]],
+    homepage = "https://github.com/microsoft/vscode-java-debug",
+    languages = { Pkg.Lang.Java },
+    categories = { Pkg.Cat.DAP },
+    ---@async
+    ---@param ctx InstallContext
+    install = function(ctx)
+        local repo = "microsoft/vscode-java-debug"
+        ---@type GitHubRelease
+        local release = ctx.requested_version
+            :map(function(version)
+                return github_client.fetch_release(repo, version)
+            end)
+            :or_else_get(function()
+                return github_client.fetch_latest_release(repo)
+            end)
+            :get_or_throw()
+
+        ---@type GitHubReleaseAsset
+        local release_asset = _.find_first(_.prop_satisfies(_.matches "%.vsix$", "name"), release.assets)
+
+        github
+            .unzip_release_file({
+                repo = repo,
+                asset_file = release_asset.name,
+                version = Optional.of(release.tag_name),
+            })
+            .with_receipt()
+
+        ctx.fs:rmrf(path.concat { "extension", "images" })
+
+        ctx:link_bin(
+            "java-debug-adapter",
+            ctx:write_shell_exec_wrapper(
+                "java-debug-adapter",
+                ("java -jar %q"):format(path.concat {
+                    "extension",
+                    "server",
+                    ("com.microsoft.java.debug.plugin-%s.jar"):format(release.tag_name),
+                })
+            )
+        )
+    end,
+}

--- a/lua/mason-registry/java-debug-adapter/init.lua
+++ b/lua/mason-registry/java-debug-adapter/init.lua
@@ -1,9 +1,7 @@
 local Pkg = require "mason-core.package"
 local github = require "mason-core.managers.github"
-local github_client = require "mason-core.managers.github.client"
 local _ = require "mason-core.functional"
 local path = require "mason-core.path"
-local Optional = require "mason-core.optional"
 
 return Pkg.new {
     name = "java-debug-adapter",
@@ -14,40 +12,14 @@ return Pkg.new {
     ---@async
     ---@param ctx InstallContext
     install = function(ctx)
-        local repo = "microsoft/vscode-java-debug"
-        ---@type GitHubRelease
-        local release = ctx.requested_version
-            :map(function(version)
-                return github_client.fetch_release(repo, version)
-            end)
-            :or_else_get(function()
-                return github_client.fetch_latest_release(repo)
-            end)
-            :get_or_throw()
-
-        ---@type GitHubReleaseAsset
-        local release_asset = _.find_first(_.prop_satisfies(_.matches "%.vsix$", "name"), release.assets)
-
         github
             .unzip_release_file({
-                repo = repo,
-                asset_file = release_asset.name,
-                version = Optional.of(release.tag_name),
+                repo = "microsoft/vscode-java-debug",
+                asset_file = _.compose(_.format "vscjava.vscode-java-debug-%s.vsix", _.gsub("^v", "")),
             })
             .with_receipt()
 
         ctx.fs:rmrf(path.concat { "extension", "images" })
-
-        ctx:link_bin(
-            "java-debug-adapter",
-            ctx:write_shell_exec_wrapper(
-                "java-debug-adapter",
-                ("java -jar %q"):format(path.concat {
-                    "extension",
-                    "server",
-                    ("com.microsoft.java.debug.plugin-%s.jar"):format(release.tag_name),
-                })
-            )
-        )
+        ctx.fs:rmrf(path.concat { "extension", "dist" })
     end,
 }

--- a/lua/mason-registry/java-test/init.lua
+++ b/lua/mason-registry/java-test/init.lua
@@ -6,14 +6,17 @@ local path = require "mason-core.path"
 return Pkg.new {
     name = "java-test",
     desc = _.dedent [[
-    Test Runner for Java. Intended to be used with
-    [nvim-jdtls](https://github.com/mfussenegger/nvim-jdtls#vscode-java-test-installation).
+        The Test Runner for Java works with java-debug-adapter to provide the following features:
+        - Run/Debug test cases
+        - Customize test configurations
+        - View test report
+        - View tests in Test Explorer
 
-    Enables support for the following test frameworks:
+        Enables support for the following test frameworks:
 
-    - JUnit 4 (v4.8.0+)
-    - JUnit 5 (v5.1.0+)
-    - TestNG (v6.8.0+)
+        - JUnit 4 (v4.8.0+)
+        - JUnit 5 (v5.1.0+)
+        - TestNG (v6.8.0+)
     ]],
     homepage = "https://github.com/microsoft/vscode-java-test",
     languages = { Pkg.Lang.Java },
@@ -24,22 +27,11 @@ return Pkg.new {
         github
             .unzip_release_file({
                 repo = "microsoft/vscode-java-test",
-                asset_file = _.compose(_.format "vscjava.vscode-java-test-%s.vsix", _.gsub("^v", "")),
+                asset_file = _.format "vscjava.vscode-java-test-%s.vsix",
             })
             .with_receipt()
 
         ctx.fs:rmrf(path.concat { "extension", "resources" })
         ctx.fs:rmrf(path.concat { "extension", "dist" })
-
-        -- not necessary, raises the following error
-        --[[
-            Failed to load extension bundles
-            Failed to get bundleInfo for bundle from com.microsoft.java.test.runner-jar-with-dependencies.jar
-        ]]
-        ctx.fs:rmrf(path.concat {
-            "extension",
-            "server",
-            "com.microsoft.java.test.runner-jar-with-dependencies.jar",
-        })
     end,
 }

--- a/lua/mason-registry/java-test/init.lua
+++ b/lua/mason-registry/java-test/init.lua
@@ -1,0 +1,50 @@
+-- https://github.com/mfussenegger/nvim-jdtls#vscode-java-test-installation
+-- use vsix because building takes a while
+local Pkg = require "mason-core.package"
+local github = require "mason-core.managers.github"
+local github_client = require "mason-core.managers.github.client"
+local _ = require "mason-core.functional"
+local path = require "mason-core.path"
+local Optional = require "mason-core.optional"
+
+return Pkg.new {
+    name = "java-test",
+    desc = _.dedent [[ Test Runner for Java ]],
+    homepage = "https://github.com/microsoft/vscode-java-test",
+    languages = { Pkg.Lang.Java },
+    categories = { Pkg.Cat.DAP },
+    ---@async
+    ---@param ctx InstallContext
+    install = function(ctx)
+        local repo = "microsoft/vscode-java-test"
+        ---@type GitHubRelease
+        local release = ctx.requested_version
+            :map(function(version)
+                return github_client.fetch_release(repo, version)
+            end)
+            :or_else_get(function()
+                return github_client.fetch_latest_release(repo)
+            end)
+            :get_or_throw()
+
+        ---@type GitHubReleaseAsset
+        local release_asset = _.find_first(_.prop_satisfies(_.matches "%.vsix$", "name"), release.assets)
+
+        github
+            .unzip_release_file({
+                repo = repo,
+                asset_file = release_asset.name,
+                version = Optional.of(release.tag_name),
+            })
+            .with_receipt()
+
+        ctx.fs:rmrf(path.concat { "extension", "resources" })
+
+        -- not necessary, raises a warning
+        ctx.fs:rmrf(path.concat {
+            "extension",
+            "server",
+            "com.microsoft.java.test.runner-jar-with-dependencies.jar",
+        })
+    end,
+}

--- a/lua/mason-registry/java-test/init.lua
+++ b/lua/mason-registry/java-test/init.lua
@@ -1,16 +1,13 @@
--- https://github.com/mfussenegger/nvim-jdtls#vscode-java-test-installation
--- use vsix because building takes a while
 local Pkg = require "mason-core.package"
 local github = require "mason-core.managers.github"
-local github_client = require "mason-core.managers.github.client"
 local _ = require "mason-core.functional"
 local path = require "mason-core.path"
-local Optional = require "mason-core.optional"
 
 return Pkg.new {
     name = "java-test",
     desc = _.dedent [[
-    Test Runner for Java. Intended to be used with [nvim-jdtls](https://github.com/mfussenegger/nvim-jdtls#vscode-java-test-installation).
+    Test Runner for Java. Intended to be used with
+    [nvim-jdtls](https://github.com/mfussenegger/nvim-jdtls#vscode-java-test-installation).
 
     Enables support for the following test frameworks:
 
@@ -24,29 +21,15 @@ return Pkg.new {
     ---@async
     ---@param ctx InstallContext
     install = function(ctx)
-        local repo = "microsoft/vscode-java-test"
-        ---@type GitHubRelease
-        local release = ctx.requested_version
-            :map(function(version)
-                return github_client.fetch_release(repo, version)
-            end)
-            :or_else_get(function()
-                return github_client.fetch_latest_release(repo)
-            end)
-            :get_or_throw()
-
-        ---@type GitHubReleaseAsset
-        local release_asset = _.find_first(_.prop_satisfies(_.matches "%.vsix$", "name"), release.assets)
-
         github
             .unzip_release_file({
-                repo = repo,
-                asset_file = release_asset.name,
-                version = Optional.of(release.tag_name),
+                repo = "microsoft/vscode-java-test",
+                asset_file = _.compose(_.format "vscjava.vscode-java-test-%s.vsix", _.gsub("^v", "")),
             })
             .with_receipt()
 
         ctx.fs:rmrf(path.concat { "extension", "resources" })
+        ctx.fs:rmrf(path.concat { "extension", "dist" })
 
         -- not necessary, raises the following error
         --[[

--- a/lua/mason-registry/java-test/init.lua
+++ b/lua/mason-registry/java-test/init.lua
@@ -9,7 +9,15 @@ local Optional = require "mason-core.optional"
 
 return Pkg.new {
     name = "java-test",
-    desc = _.dedent [[ Test Runner for Java ]],
+    desc = _.dedent [[
+    Test Runner for Java. Intended to be used with [nvim-jdtls](https://github.com/mfussenegger/nvim-jdtls#vscode-java-test-installation).
+
+    Enables support for the following test frameworks:
+
+    - JUnit 4 (v4.8.0+)
+    - JUnit 5 (v5.1.0+)
+    - TestNG (v6.8.0+)
+    ]],
     homepage = "https://github.com/microsoft/vscode-java-test",
     languages = { Pkg.Lang.Java },
     categories = { Pkg.Cat.DAP },
@@ -40,7 +48,11 @@ return Pkg.new {
 
         ctx.fs:rmrf(path.concat { "extension", "resources" })
 
-        -- not necessary, raises a warning
+        -- not necessary, raises the following error
+        --[[
+            Failed to load extension bundles
+            Failed to get bundleInfo for bundle from com.microsoft.java.test.runner-jar-with-dependencies.jar
+        ]]
         ctx.fs:rmrf(path.concat {
             "extension",
             "server",

--- a/lua/mason/mappings/language.lua
+++ b/lua/mason/mappings/language.lua
@@ -52,7 +52,7 @@ return {
   haxe = { "haxe-language-server" },
   hoon = { "hoon-language-server" },
   html = { "erb-lint", "html-lsp", "prettier", "prettierd" },
-  java = { "clang-format", "jdtls" },
+  java = { "clang-format", "java-debug-adapter", "java-test", "jdtls" },
   javascript = { "chrome-debug-adapter", "clang-format", "deno", "eslint-lsp", "eslint_d", "firefox-debug-adapter", "js-debug-adapter", "node-debug2-adapter", "prettier", "prettierd", "quick-lint-js", "rome", "typescript-language-server", "xo" },
   jinja = { "curlylint", "djlint" },
   json = { "cfn-lint", "clang-format", "fixjson", "jq", "json-lsp", "prettier", "prettierd", "spectral-language-server" },


### PR DESCRIPTION
closes https://github.com/williamboman/mason.nvim/issues/433

I've opted for using the prebuilt files extracted from .vsix because maven takes a while to build.

Not sure if we should link `java-test` or not, since it's more like a 'lib' than an executable (should it still be in the DAP category?).

usage with [nvim-jdtls#java-debug](https://github.com/mfussenegger/nvim-jdtls#java-debug-installation) / [nvim-jdtls#vscode-java-test](https://github.com/mfussenegger/nvim-jdtls#vscode-java-test-installation):
```lua
local function get_install_path(package_name)
  return require("mason-registry").get_package(package_name):get_install_path()
end

local bundles = {
  vim.fn.glob(
    -- or
    -- get_install_path("java-debug-adapter") .. "extension/server/com.microsoft.java.debug.plugin-*",
    vim.fn.stdpath "data"
      .. "/mason/packages/java-debug-adapter/extension/server/com.microsoft.java.debug.plugin-*.jar",
    true
  ),
}

vim.list_extend(
  bundles,
  vim.split(
    vim.fn.glob(
      -- or
      -- get_install_path("java-test") .. "extension/server/*.jar",
      vim.fn.stdpath "data" .. "/mason/packages/java-test/extension/server/*.jar",
      true
    ),
    "\n"
  )
```