### PR TITLE
Make elixir-ls installer expose debugger binary

### DIFF
--- a/lua/mason-registry/elixir-ls/init.lua
+++ b/lua/mason-registry/elixir-ls/init.lua
@@ -8,8 +8,6 @@ return Pkg.new {
     desc = _.dedent [[
         A frontend-independent IDE "smartness" server for Elixir. Implements the "Language Server Protocol" standard and
         provides debugger support via the "Debug Adapter Protocol".
-
-        Exposes "elixir-ls" and "elixir-ls-debugger" executables.
     ]],
     homepage = "https://github.com/elixir-lsp/elixir-ls",
     languages = { Pkg.Lang.Elixir },

--- a/lua/mason-registry/elixir-ls/init.lua
+++ b/lua/mason-registry/elixir-ls/init.lua
@@ -8,6 +8,8 @@ return Pkg.new {
     desc = _.dedent [[
         A frontend-independent IDE "smartness" server for Elixir. Implements the "Language Server Protocol" standard and
         provides debugger support via the "Debug Adapter Protocol".
+
+        Exposes "elixir-ls" and "elixir-ls-debugger" executables.
     ]],
     homepage = "https://github.com/elixir-lsp/elixir-ls",
     languages = { Pkg.Lang.Elixir },
@@ -23,5 +25,6 @@ return Pkg.new {
             .with_receipt()
 
         ctx:link_bin("elixir-ls", platform.is.win and "language_server.bat" or "language_server.sh")
+        ctx:link_bin("elixir-ls-debugger", platform.is.win and "debugger.bat" or "debugger.sh")
     end,
 }


### PR DESCRIPTION
This commit makes elixir-ls installer link not just a language server binary, but also a debugger one.

Additionally, it explicitly states the names of the binaries exposed, since nvim-lspconfig does not set elixir-ls command by default.