### PR TITLE
feat: add erg-language-server

### DIFF
--- a/lua/mason-registry/erg-language-server/init.lua
+++ b/lua/mason-registry/erg-language-server/init.lua
@@ -1,0 +1,13 @@
+local Pkg = require "mason-core.package"
+local cargo = require "mason-core.managers.cargo"
+
+return Pkg.new {
+    name = "erg-language-server",
+    desc = [[ELS is a language server for the Erg programing language.]],
+    homepage = "https://github.com/erg-lang/erg-language-server",
+    languages = { Pkg.Lang.Erg },
+    categories = { Pkg.Cat.LSP },
+    install = cargo.crate("els", {
+        bin = { "els" },
+    }),
+}

--- a/lua/mason-registry/erg-language-server/init.lua
+++ b/lua/mason-registry/erg-language-server/init.lua
@@ -1,5 +1,7 @@
 local Pkg = require "mason-core.package"
-local cargo = require "mason-core.managers.cargo"
+local github = require "mason-core.managers.github"
+local platform = require "mason-core.platform"
+local _ = require "mason-core.functional"
 
 return Pkg.new {
     name = "erg-language-server",
@@ -7,7 +9,37 @@ return Pkg.new {
     homepage = "https://github.com/erg-lang/erg-language-server",
     languages = { Pkg.Lang.Erg },
     categories = { Pkg.Cat.LSP },
-    install = cargo.crate("els", {
-        bin = { "els" },
-    }),
+    ---@async
+    ---@param ctx InstallContext
+    install = function(ctx)
+        local repo = "erg-lang/erg-language-server"
+        local asset_file = _.coalesce(
+            _.when(platform.is.mac_x64, "els-x86_64-apple-darwin.tar.gz"),
+            _.when(platform.is.mac_arm64, "els-aarch64-apple-darwin.tar.gz"),
+            _.when(platform.is.linux_arm64_gnu, "els-aarch64-unknown-linux-gnu.tar.gz"),
+            _.when(platform.is.linux_x64_gnu, "els-x86_64-unknown-linux-gnu.tar.gz"),
+            _.when(platform.is.linux_x64, "els-x86_64-unknown-linux-musl.tar.gz"),
+            _.when(platform.is.win_x64, "els-x86_64-pc-windows-msvc.zip")
+        )
+        platform.when {
+            unix = function()
+                github
+                    .untargz_release_file({
+                        repo = repo,
+                        asset_file = asset_file,
+                    })
+                    .with_receipt()
+                ctx:link_bin("els", "els")
+            end,
+            win = function()
+                github
+                    .unzip_release_file({
+                        repo = repo,
+                        asset_file = asset_file,
+                    })
+                    .with_receipt()
+                ctx:link_bin("els", "els.exe")
+            end,
+        }
+    end,
 }

--- a/lua/mason-registry/index.lua
+++ b/lua/mason-registry/index.lua
@@ -62,6 +62,7 @@ return {
   ["ember-language-server"] = "mason-registry.ember-language-server",
   ["emmet-ls"] = "mason-registry.emmet-ls",
   ["erb-lint"] = "mason-registry.erb-lint",
+  ["erg-language-server"] = "mason-registry.erg-language-server",
   ["erlang-ls"] = "mason-registry.erlang-ls",
   esbonio = "mason-registry.esbonio",
   ["eslint-lsp"] = "mason-registry.eslint-lsp",

--- a/lua/mason/mappings/language.lua
+++ b/lua/mason/mappings/language.lua
@@ -37,6 +37,7 @@ return {
   elm = { "elm-format", "elm-language-server" },
   ember = { "ember-language-server" },
   emmet = { "emmet-ls" },
+  erg = { "erg-language-server" },
   erlang = { "erlang-ls" },
   ["f#"] = { "fantomas", "fsautocomplete", "netcoredbg" },
   flow = { "prettier", "prettierd" },


### PR DESCRIPTION
Hi, first of all, thanks for your amazing work!

Recently, I have added the [erg-language-server](https://github.com/erg-lang/erg-language-server) to `nvim-lspconfig` : PR -> https://github.com/neovim/nvim-lspconfig/pull/2165

It would be really nice if I can add this to `mason.nvim`.

## [Erg Programming Language](https://erg-lang.org/)

A generic statically typed language that can deeply improve the Python ecosystem.