### PR TITLE
fix(dhall): new assets have capitalized naming

### DIFF
--- a/lua/mason-registry/dhall-lsp/init.lua
+++ b/lua/mason-registry/dhall-lsp/init.lua
@@ -28,9 +28,9 @@ return Pkg.new {
 
         local asset_name_pattern = assert(
             _.coalesce(
-                _.when(platform.is.mac, "dhall%-lsp%-server%-.+%-x86_64%-macos.tar.bz2"),
-                _.when(platform.is.linux_x64, "dhall%-lsp%-server%-.+%-x86_64%-linux.tar.bz2"),
-                _.when(platform.is.win_x64, "dhall%-lsp%-server%-.+%-x86_64%-windows.zip")
+                _.when(platform.is.mac, "dhall%-lsp%-server%-.+%-x86_64%-[mM]acos.tar.bz2"),
+                _.when(platform.is.linux_x64, "dhall%-lsp%-server%-.+%-x86_64%-[lL]inux.tar.bz2"),
+                _.when(platform.is.win_x64, "dhall%-lsp%-server%-.+%-x86_64%-[wW]indows.zip")
             )
         )
         local dhall_lsp_server_asset =


### PR DESCRIPTION
fixes the following error

```console
...acker/start/mason.nvim/lua/mason-core/installer/init.lua:113: ...r/start/mason.nvim/lua/mason-registry/dhall-lsp/init.lua:58: Unable to find the dhall-lsp-server release asset in the GitHub release.
```

see
- https://github.com/dhall-lang/dhall-haskell/releases/tag/1.41.2
- https://github.com/dhall-lang/dhall-haskell/releases/tag/1.41.1
