### PR TITLE
feat(github): use proxy API for fetching latest release

### DIFF
--- a/lua/mason-core/managers/github/init.lua
+++ b/lua/mason-core/managers/github/init.lua
@@ -165,7 +165,7 @@ function M.check_outdated_primary_package_release(receipt)
     if source.type ~= "github_release" and source.type ~= "github_release_file" then
         return Result.failure "Receipt does not have a primary source of type (github_release|github_release_file)."
     end
-    return client.fetch_latest_release(source.repo, { tag_name_pattern = source.tag_name_pattern }):map_catching(
+    return client.fetch_latest_release(source.repo):map_catching(
         ---@param latest_release GitHubRelease
         function(latest_release)
             if source.release ~= latest_release.tag_name then

--- a/tests/mason-core/managers/github_client_spec.lua
+++ b/tests/mason-core/managers/github_client_spec.lua
@@ -1,48 +1,9 @@
-local spy = require "luassert.spy"
 local stub = require "luassert.stub"
 local client = require "mason-core.managers.github.client"
 local spawn = require "mason-core.spawn"
 local Result = require "mason-core.result"
 
 describe("github client", function()
-    ---@type GitHubRelease
-    local release = {
-        tag_name = "v0.1.0",
-        prerelease = false,
-        draft = false,
-        assets = {},
-    }
-
-    local function stub_release(mock)
-        return setmetatable(mock, { __index = release })
-    end
-
-    it("should identify stable prerelease", function()
-        local predicate = client.release_predicate {
-            include_prerelease = false,
-        }
-
-        assert.is_false(predicate(stub_release { prerelease = true }))
-        assert.is_true(predicate(stub_release { prerelease = false }))
-    end)
-
-    it("should identify stable release with tag name pattern", function()
-        local predicate = client.release_predicate {
-            tag_name_pattern = "^lsp%-server.*$",
-        }
-
-        assert.is_false(predicate(stub_release { tag_name = "v0.1.0" }))
-        assert.is_true(predicate(stub_release { tag_name = "lsp-server-v0.1.0" }))
-    end)
-
-    it("should identify stable release", function()
-        local predicate = client.release_predicate {}
-
-        assert.is_true(predicate(stub_release { tag_name = "v0.1.0" }))
-        assert.is_false(predicate(stub_release { prerelease = true }))
-        assert.is_false(predicate(stub_release { draft = true }))
-    end)
-
     it("should provide query parameters in api calls", function()
         stub(spawn, "gh")
         spawn.gh.returns(Result.success { stdout = "response data" })


### PR DESCRIPTION
This uses a globally distributed, edge-cached, proxy [1] for a very common
touchpoint with the GitHub API. This is already done for fetching
the latest tag, now expanding to latest release as well.

[1]: https://github.com/williamboman/github-api-proxy
