### PR TITLE
feat(registry): add iferr tool for Go

### DIFF
--- a/lua/mason-registry/iferr/init.lua
+++ b/lua/mason-registry/iferr/init.lua
@@ -1,0 +1,11 @@
+local Pkg = require "mason-core.package"
+local go = require "mason-core.managers.go"
+
+return Pkg.new {
+    name = "iferr",
+    desc = [[Go tool to generate if err != nil block for the current function.]],
+    homepage = "https://github.com/koron/iferr",
+    categories = {},
+    languages = { Pkg.Lang.Go },
+    install = go.packages { "github.com/koron/iferr", bin = { "iferr" } },
+}

--- a/lua/mason-registry/index.lua
+++ b/lua/mason-registry/index.lua
@@ -99,6 +99,7 @@ return {
   ["haxe-language-server"] = "mason-registry.haxe-language-server",
   ["hoon-language-server"] = "mason-registry.hoon-language-server",
   ["html-lsp"] = "mason-registry.html-lsp",
+  iferr = "mason-registry.iferr",
   impl = "mason-registry.impl",
   intelephense = "mason-registry.intelephense",
   isort = "mason-registry.isort",

--- a/lua/mason/mappings/language.lua
+++ b/lua/mason/mappings/language.lua
@@ -44,7 +44,7 @@ return {
   flux = { "flux-lsp" },
   fortran = { "fortls" },
   gitcommit = { "gitlint" },
-  go = { "delve", "djlint", "go-debug-adapter", "gofumpt", "goimports", "goimports-reviser", "golangci-lint", "golangci-lint-langserver", "golines", "gomodifytags", "gopls", "gotests", "gotestsum", "impl", "json-to-struct", "revive", "staticcheck" },
+  go = { "delve", "djlint", "go-debug-adapter", "gofumpt", "goimports", "goimports-reviser", "golangci-lint", "golangci-lint-langserver", "golines", "gomodifytags", "gopls", "gotests", "gotestsum", "iferr", "impl", "json-to-struct", "revive", "staticcheck" },
   gradle = { "gradle-language-server" },
   graphql = { "graphql-language-service-cli", "prettier", "prettierd" },
   groovy = { "groovy-language-server" },


### PR DESCRIPTION
Hi! I've recently been configuring this other package https://github.com/olexsmir/gopher.nvim and most of the supported tools are included in mason already, so I wondered if `iferr` would also be a good addition.

Thanks a lot in advance and thanks for writing this plugin! it makes my life so much easier.