### PR TITLE
feat(registry): add dprint formatter

### DIFF
--- a/lua/mason-registry/dprint/init.lua
+++ b/lua/mason-registry/dprint/init.lua
@@ -1,0 +1,11 @@
+local Pkg = require "mason-core.package"
+local npm = require "mason-core.managers.npm"
+
+return Pkg.new {
+    name = "dprint",
+    desc = [[A pluggable and configurable code formatting platform written in Rust.]],
+    homepage = "https://dprint.dev/",
+    languages = {},
+    categories = { Pkg.Cat.Formatter },
+    install = npm.packages { "dprint", bin = { "dprint" } },
+}

--- a/lua/mason-registry/dprint/init.lua
+++ b/lua/mason-registry/dprint/init.lua
@@ -1,5 +1,8 @@
 local Pkg = require "mason-core.package"
-local npm = require "mason-core.managers.npm"
+local github = require "mason-core.managers.github"
+local std = require "mason-core.managers.std"
+local _ = require "mason-core.functional"
+local platform = require "mason-core.platform"
 
 return Pkg.new {
     name = "dprint",
@@ -7,5 +10,22 @@ return Pkg.new {
     homepage = "https://dprint.dev/",
     languages = {},
     categories = { Pkg.Cat.Formatter },
-    install = npm.packages { "dprint", bin = { "dprint" } },
+    ---@async
+    ---@param ctx InstallContext
+    install = function(ctx)
+        github
+            .unzip_release_file({
+                repo = "dprint/dprint",
+                asset_file = _.coalesce(
+                    _.when(platform.is.mac_arm64, "dprint-aarch64-apple-darwin.zip"),
+                    _.when(platform.is.mac_x64, "dprint-x86_64-apple-darwin.zip"),
+                    _.when(platform.is.linux_arm64_gnu, "dprint-aarch64-unknown-linux-gnu.zip"),
+                    _.when(platform.is.linux_x64_gnu, "dprint-x86_64-unknown-linux-gnu.zip"),
+                    _.when(platform.is.win_x64, "dprint-x86_64-pc-windows-msvc.zip")
+                ),
+            })
+            .with_receipt()
+        std.chmod("+x", { "dprint" })
+        ctx:link_bin("dprint", platform.is.win and "dprint.exe" or "dprint")
+    end,
 }

--- a/lua/mason-registry/index.lua
+++ b/lua/mason-registry/index.lua
@@ -55,6 +55,7 @@ return {
   djlint = "mason-registry.djlint",
   ["dockerfile-language-server"] = "mason-registry.dockerfile-language-server",
   ["dot-language-server"] = "mason-registry.dot-language-server",
+  dprint = "mason-registry.dprint",
   ["editorconfig-checker"] = "mason-registry.editorconfig-checker",
   efm = "mason-registry.efm",
   ["elixir-ls"] = "mason-registry.elixir-ls",


### PR DESCRIPTION
closes #558 

- uses npm not cargo for installation
  - the npm package of dprint provides a pre-compiled binary
- no languages specified, as it depends on selected plugins in per-project config file and dprint itself does not provide any language support by default