### PR TITLE
fix(taplo): rename files to match upstream

### DIFF
--- a/lua/mason-registry/taplo/init.lua
+++ b/lua/mason-registry/taplo/init.lua
@@ -3,6 +3,7 @@ local cargo = require "mason-core.managers.cargo"
 local github = require "mason-core.managers.github"
 local _ = require "mason-core.functional"
 local platform = require "mason-core.platform"
+local std = require "mason-core.managers.std"
 
 local coalesce, when = _.coalesce, _.when
 
@@ -27,6 +28,7 @@ return Pkg.new {
                     out_file = "taplo",
                 })
                 .with_receipt()
+            std.chmod("+x", { "taplo" })
             ctx:link_bin("taplo", "taplo")
         else
             cargo

--- a/lua/mason-registry/taplo/init.lua
+++ b/lua/mason-registry/taplo/init.lua
@@ -1,5 +1,4 @@
 local Pkg = require "mason-core.package"
-local cargo = require "mason-core.managers.cargo"
 local github = require "mason-core.managers.github"
 local _ = require "mason-core.functional"
 local platform = require "mason-core.platform"
@@ -16,27 +15,37 @@ return Pkg.new {
     ---@async
     ---@param ctx InstallContext
     install = function(ctx)
-        local asset_file = coalesce(
-            when(platform.is.mac, "taplo-full-darwin-x86_64.gz"),
-            when(platform.is.linux_x64, "taplo-full-linux-x86_64.gz")
-        )
-        if asset_file then
-            github
-                .gunzip_release_file({
-                    repo = "tamasfe/taplo",
-                    asset_file = asset_file,
-                    out_file = "taplo",
-                })
-                .with_receipt()
-            std.chmod("+x", { "taplo" })
-            ctx:link_bin("taplo", "taplo")
-        else
-            cargo
-                .install("taplo-cli", {
-                    features = "lsp,toml-test",
-                    bin = { "taplo" },
-                })
-                .with_receipt()
-        end
+        platform.when {
+            unix = function()
+                github
+                    .gunzip_release_file({
+                        repo = "tamasfe/taplo",
+                        asset_file = coalesce(
+                            when(platform.is.mac_arm64, "taplo-full-darwin-aarch64.gz"),
+                            when(platform.is.mac_x64, "taplo-full-darwin-x86_64.gz"),
+                            when(platform.is.linux_x64, "taplo-full-linux-x86_64.gz"),
+                            when(platform.is.linux_x86, "taplo-full-linux-x86.gz"),
+                            when(platform.is.linux_arm64, "taplo-full-linux-aarch64.gz")
+                        ),
+                        out_file = "taplo",
+                    })
+                    .with_receipt()
+                std.chmod("+x", { "taplo" })
+                ctx:link_bin("taplo", "taplo")
+            end,
+            win = function()
+                github
+                    .unzip_release_file({
+                        repo = "tamasfe/taplo",
+                        asset_file = coalesce(
+                            when(platform.is.win_x64, "taplo-full-windows-x86_64.zip"),
+                            when(platform.is.win_x86, "taplo-full-windows-x86.zip")
+                        ),
+                        out_file = "taplo.zip",
+                    })
+                    .with_receipt()
+                ctx:link_bin("taplo", "taplo.exe")
+            end,
+        }
     end,
 }

--- a/lua/mason-registry/taplo/init.lua
+++ b/lua/mason-registry/taplo/init.lua
@@ -16,14 +16,15 @@ return Pkg.new {
     ---@param ctx InstallContext
     install = function(ctx)
         local asset_file = coalesce(
-            when(platform.is.mac, "taplo-full-x86_64-apple-darwin-gnu.tar.gz"),
-            when(platform.is.linux_x64, "taplo-full-x86_64-unknown-linux-gnu.tar.gz")
+            when(platform.is.mac, "taplo-full-darwin-x86_64.gz"),
+            when(platform.is.linux_x64, "taplo-full-linux-x86_64.gz")
         )
         if asset_file then
             github
-                .untargz_release_file({
+                .gunzip_release_file({
                     repo = "tamasfe/taplo",
                     asset_file = asset_file,
+                    out_file = "taplo",
                 })
                 .with_receipt()
             ctx:link_bin("taplo", "taplo")


### PR DESCRIPTION
Fixes #612

Does not address architectures. Tested on linux/x86_64.