### PR TITLE
Fix error when using client-side github provider

### DIFF
--- a/lua/mason/providers/client/init.lua
+++ b/lua/mason/providers/client/init.lua
@@ -1,6 +1,6 @@
 ---@type Provider
 return {
-    gh = require "mason.providers.client.gh",
+    github = require "mason.providers.client.gh",
     npm = require "mason.providers.client.npm",
     pypi = require "mason.providers.client.pypi",
 }


### PR DESCRIPTION
Wrong name used for github.