### PR TITLE
fix(gem): don't format executable

### DIFF
--- a/lua/mason-core/managers/gem/init.lua
+++ b/lua/mason-core/managers/gem/init.lua
@@ -78,6 +78,7 @@ function M.install(packages)
     ctx.spawn.gem {
         "install",
         "--no-user-install",
+        "--no-format-executable",
         "--install-dir=.",
         "--bindir=bin",
         "--no-document",

--- a/tests/mason-core/managers/gem_spec.lua
+++ b/tests/mason-core/managers/gem_spec.lua
@@ -20,6 +20,7 @@ describe("gem manager", function()
             assert.spy(ctx.spawn.gem).was_called_with(match.tbl_containing {
                 "install",
                 "--no-user-install",
+                "--no-format-executable",
                 "--install-dir=.",
                 "--bindir=bin",
                 "--no-document",


### PR DESCRIPTION
Closes #570.
Closes williamboman/mason-lspconfig.nvim#94.
