### PR TITLE
feat(ui): add MasonNormal highlight

### DIFF
--- a/lua/mason-core/ui/display.lua
+++ b/lua/mason-core/ui/display.lua
@@ -380,16 +380,16 @@ function M.new_view_only_win(name, filetype)
 
         -- window options
         for key, value in pairs(win_opts) do
-            vim.wo[win_id][key] = value
+            vim.api.nvim_win_set_option(win_id, key, value)
         end
 
         if window_opts.winhighlight then
-            vim.wo[win_id].winhighlight = table.concat(window_opts.winhighlight, ",")
+            vim.api.nvim_win_set_option(win_id, "winhighlight", table.concat(window_opts.winhighlight, ","))
         end
 
         -- buffer options
         for key, value in pairs(buf_opts) do
-            vim.bo[bufnr][key] = value
+            vim.api.nvim_buf_set_option(bufnr, key, value)
         end
 
         vim.cmd [[ syntax clear ]]

--- a/lua/mason-core/ui/display.lua
+++ b/lua/mason-core/ui/display.lua
@@ -165,9 +165,9 @@ end
 -- exported for tests
 M._render_node = render_node
 
----@alias WindowOpts {effects: table<string, fun()>, highlight_groups: table<string, table>, border: string|table}
+---@alias WindowOpts { effects?: table<string, fun()>, winhighlight?: string[], border?: string|table }
 
----@param opts WindowOpenOpts
+---@param opts WindowOpts
 ---@param sizes_only boolean Whether to only return properties that control the window size.
 local function create_popup_window_opts(opts, sizes_only)
     local win_height = vim.o.lines - vim.o.cmdheight - 2 -- Add margin for status and buffer line
@@ -348,10 +348,9 @@ function M.new_view_only_win(name, filetype)
         end
     end
 
-    ---@param opts WindowOpenOpts
-    local function open(opts)
+    local function open()
         bufnr = vim.api.nvim_create_buf(false, true)
-        win_id = vim.api.nvim_open_win(bufnr, true, create_popup_window_opts(opts, false))
+        win_id = vim.api.nvim_open_win(bufnr, true, create_popup_window_opts(window_opts, false))
 
         registered_effect_handlers = window_opts.effects
         registered_keybinds = {}
@@ -381,12 +380,16 @@ function M.new_view_only_win(name, filetype)
 
         -- window options
         for key, value in pairs(win_opts) do
-            vim.api.nvim_win_set_option(win_id, key, value)
+            vim.wo[win_id][key] = value
+        end
+
+        if window_opts.winhighlight then
+            vim.wo[win_id].winhighlight = table.concat(window_opts.winhighlight, ",")
         end
 
         -- buffer options
         for key, value in pairs(buf_opts) do
-            vim.api.nvim_buf_set_option(bufnr, key, value)
+            vim.bo[bufnr][key] = value
         end
 
         vim.cmd [[ syntax clear ]]
@@ -466,16 +469,9 @@ function M.new_view_only_win(name, filetype)
             assert(renderer ~= nil, "No view function has been registered. Call .view() before .init().")
             assert(unsubscribe ~= nil, "No state has been registered. Call .state() before .init().")
             window_opts = opts
-            if opts.highlight_groups then
-                for hl_name, args in pairs(opts.highlight_groups) do
-                    vim.api.nvim_set_hl(0, hl_name, args)
-                end
-            end
             has_initiated = true
         end,
-        ---@alias WindowOpenOpts { border: string | table }
-        ---@type fun(opts: WindowOpenOpts)
-        open = vim.schedule_wrap(function(opts)
+        open = vim.schedule_wrap(function()
             log.trace "Opening window"
             assert(has_initiated, "Display has not been initiated, cannot open.")
             if win_id and vim.api.nvim_win_is_valid(win_id) then
@@ -483,7 +479,7 @@ function M.new_view_only_win(name, filetype)
                 return
             end
             unsubscribe(false)
-            open(opts)
+            open()
             draw(renderer(get_state()))
         end),
         ---@type fun()

--- a/lua/mason/init.lua
+++ b/lua/mason/init.lua
@@ -16,7 +16,6 @@ function M.setup(config)
         vim.env.PATH = vim.env.PATH .. platform.path_sep .. path.bin_prefix()
     end
 
-    require "mason.ui.colors"
     require "mason.api.command"
 end
 

--- a/lua/mason/init.lua
+++ b/lua/mason/init.lua
@@ -16,6 +16,7 @@ function M.setup(config)
         vim.env.PATH = vim.env.PATH .. platform.path_sep .. path.bin_prefix()
     end
 
+    require "mason.ui.colors"
     require "mason.api.command"
 end
 

--- a/lua/mason/ui/colors.lua
+++ b/lua/mason/ui/colors.lua
@@ -1,0 +1,27 @@
+local hl_groups = {
+    MasonNormal = { link = "NormalFloat" },
+    MasonHeader = { bold = true, fg = "#222222", bg = "#DCA561", default = true },
+    MasonHeaderSecondary = { bold = true, fg = "#222222", bg = "#56B6C2", default = true },
+
+    MasonHighlight = { fg = "#56B6C2", default = true },
+    MasonHighlightBlock = { bg = "#56B6C2", fg = "#222222", default = true },
+    MasonHighlightBlockBold = { bg = "#56B6C2", fg = "#222222", bold = true, default = true },
+
+    MasonHighlightSecondary = { fg = "#DCA561", default = true },
+    MasonHighlightBlockSecondary = { bg = "#DCA561", fg = "#222222", default = true },
+    MasonHighlightBlockBoldSecondary = { bg = "#DCA561", fg = "#222222", bold = true, default = true },
+
+    MasonLink = { link = "MasonHighlight", default = true },
+
+    MasonMuted = { fg = "#888888", default = true },
+    MasonMutedBlock = { bg = "#888888", fg = "#222222", default = true },
+    MasonMutedBlockBold = { bg = "#888888", fg = "#222222", bold = true, default = true },
+
+    MasonError = { fg = "#f44747", default = true },
+
+    MasonHeading = { bold = true, default = true },
+}
+
+for name, hl in pairs(hl_groups) do
+    vim.api.nvim_set_hl(0, name, hl)
+end

--- a/lua/mason/ui/init.lua
+++ b/lua/mason/ui/init.lua
@@ -1,11 +1,8 @@
-local settings = require "mason.settings"
 local M = {}
 
 function M.open()
     local api = require "mason.ui.instance"
-    api.window.open {
-        border = settings.current.ui.border,
-    }
+    api.window.open()
 end
 
 ---@param view string

--- a/lua/mason/ui/instance.lua
+++ b/lua/mason/ui/instance.lua
@@ -4,7 +4,6 @@ local Ui = require "mason-core.ui"
 local a = require "mason-core.async"
 local control = require "mason-core.async.control"
 local _ = require "mason-core.functional"
-local palette = require "mason.ui.palette"
 local Package = require "mason-core.package"
 local settings = require "mason.settings"
 local notify = require "mason-core.notify"
@@ -17,6 +16,8 @@ local Main = require "mason.ui.components.main"
 local LanguageFilter = require "mason.ui.components.language-filter"
 
 local Semaphore = control.Semaphore
+
+require "mason.ui.colors"
 
 ---@param state InstallerUiState
 local function GlobalKeybinds(state)
@@ -605,6 +606,7 @@ end
 
 window.init {
     effects = effects,
+    border = settings.current.ui.border,
     winhighlight = {
         "NormalFloat:MasonNormal",
     },

--- a/lua/mason/ui/instance.lua
+++ b/lua/mason/ui/instance.lua
@@ -605,7 +605,9 @@ end
 
 window.init {
     effects = effects,
-    highlight_groups = palette.highlight_groups,
+    winhighlight = {
+        "NormalFloat:MasonNormal",
+    },
 }
 
 if settings.current.ui.check_outdated_packages_on_open then

--- a/lua/mason/ui/palette.lua
+++ b/lua/mason/ui/palette.lua
@@ -1,28 +1,5 @@
 local M = {}
 
-M.highlight_groups = {
-    MasonHeader = { bold = true, fg = "#222222", bg = "#DCA561", default = true },
-    MasonHeaderSecondary = { bold = true, fg = "#222222", bg = "#56B6C2", default = true },
-
-    MasonHighlight = { fg = "#56B6C2", default = true },
-    MasonHighlightBlock = { bg = "#56B6C2", fg = "#222222", default = true },
-    MasonHighlightBlockBold = { bg = "#56B6C2", fg = "#222222", bold = true, default = true },
-
-    MasonHighlightSecondary = { fg = "#DCA561", default = true },
-    MasonHighlightBlockSecondary = { bg = "#DCA561", fg = "#222222", default = true },
-    MasonHighlightBlockBoldSecondary = { bg = "#DCA561", fg = "#222222", bold = true, default = true },
-
-    MasonLink = { link = "MasonHighlight", default = true },
-
-    MasonMuted = { fg = "#888888", default = true },
-    MasonMutedBlock = { bg = "#888888", fg = "#222222", default = true },
-    MasonMutedBlockBold = { bg = "#888888", fg = "#222222", bold = true, default = true },
-
-    MasonError = { fg = "#f44747", default = true },
-
-    MasonHeading = { bold = true, default = true },
-}
-
 local function hl(highlight)
     return function(text)
         return { text, highlight }

--- a/tests/mason-core/ui_spec.lua
+++ b/tests/mason-core/ui_spec.lua
@@ -181,7 +181,7 @@ describe("integration test", function()
                 winhighlight = {
                     "NormalFloat:MasonNormal",
                     "CursorLine:MasonCursorLine",
-                }
+                },
             }
             window.open { border = "none" }
 
@@ -197,7 +197,9 @@ describe("integration test", function()
             assert.spy(win_set_option).was_called_with(match.is_number(), "signcolumn", "no")
             assert.spy(win_set_option).was_called_with(match.is_number(), "colorcolumn", "")
             assert.spy(win_set_option).was_called_with(match.is_number(), "cursorline", true)
-            assert.spy(win_set_option).was_called_with(match.is_number(), "winhighlight", "NormalFloat:MasonNormal,CursorLine:MasonCursorLine")
+            assert
+                .spy(win_set_option)
+                .was_called_with(match.is_number(), "winhighlight", "NormalFloat:MasonNormal,CursorLine:MasonCursorLine")
 
             assert.spy(buf_set_option).was_called(10)
             assert.spy(buf_set_option).was_called_with(match.is_number(), "modifiable", false)

--- a/tests/mason-core/ui_spec.lua
+++ b/tests/mason-core/ui_spec.lua
@@ -179,17 +179,11 @@ describe("integration test", function()
                     ["EFFECT"] = function() end,
                     ["R_EFFECT"] = function() end,
                 },
-                highlight_groups = {
-                    MyHighlight = { bold = true },
-                },
             }
             window.open { border = "none" }
 
             -- Initial window and buffer creation + initial render
             a.scheduler()
-
-            assert.spy(set_hl).was_called(1)
-            assert.spy(set_hl).was_called_with(match.is_number(), "MyHighlight", match.same { bold = true })
 
             assert.spy(win_set_option).was_called(8)
             assert.spy(win_set_option).was_called_with(match.is_number(), "number", false)

--- a/tests/mason-core/ui_spec.lua
+++ b/tests/mason-core/ui_spec.lua
@@ -170,7 +170,6 @@ describe("integration test", function()
             local win_set_option = spy.on(vim.api, "nvim_win_set_option")
             local set_lines = spy.on(vim.api, "nvim_buf_set_lines")
             local set_extmark = spy.on(vim.api, "nvim_buf_set_extmark")
-            local set_hl = spy.on(vim.api, "nvim_set_hl")
             local add_highlight = spy.on(vim.api, "nvim_buf_add_highlight")
             local set_keymap = spy.on(vim.keymap, "set")
 
@@ -179,13 +178,17 @@ describe("integration test", function()
                     ["EFFECT"] = function() end,
                     ["R_EFFECT"] = function() end,
                 },
+                winhighlight = {
+                    "NormalFloat:MasonNormal",
+                    "CursorLine:MasonCursorLine",
+                }
             }
             window.open { border = "none" }
 
             -- Initial window and buffer creation + initial render
             a.scheduler()
 
-            assert.spy(win_set_option).was_called(8)
+            assert.spy(win_set_option).was_called(9)
             assert.spy(win_set_option).was_called_with(match.is_number(), "number", false)
             assert.spy(win_set_option).was_called_with(match.is_number(), "relativenumber", false)
             assert.spy(win_set_option).was_called_with(match.is_number(), "wrap", false)
@@ -194,6 +197,7 @@ describe("integration test", function()
             assert.spy(win_set_option).was_called_with(match.is_number(), "signcolumn", "no")
             assert.spy(win_set_option).was_called_with(match.is_number(), "colorcolumn", "")
             assert.spy(win_set_option).was_called_with(match.is_number(), "cursorline", true)
+            assert.spy(win_set_option).was_called_with(match.is_number(), "winhighlight", "NormalFloat:MasonNormal,CursorLine:MasonCursorLine")
 
             assert.spy(buf_set_option).was_called(10)
             assert.spy(buf_set_option).was_called_with(match.is_number(), "modifiable", false)


### PR DESCRIPTION
This allows for further customization of Mason's popup window (more
specifically its background color). Note that this is already possible
by changing the `NormalFloat` highlight, but it impacts floating windows
globally. We leverage 'winhighlight' to introduce a specific
`MasonNormal` highlight group to allow targeting Mason only.

Closes #635.
