### PR TITLE
feat(registry): add colorgen-nvim

### DIFF
--- a/lua/mason-registry/colorgen-nvim/init.lua
+++ b/lua/mason-registry/colorgen-nvim/init.lua
@@ -1,0 +1,17 @@
+local Pkg = require "mason-core.package"
+local cargo = require "mason-core.managers.cargo"
+
+return Pkg.new {
+    name = "colorgen-nvim",
+    desc = [[Blazingly fast colorscheme generator for Neovim written in Rust]],
+    homepage = "https://github.com/ChristianChiarulli/colorgen-nvim",
+    languages = {},
+    categories = { Pkg.Cat.Compiler },
+    install = cargo.crate("colorgen-nvim", {
+        git = {
+            url = "https://github.com/ChristianChiarulli/colorgen-nvim",
+            tag = false,
+        },
+        bin = { "colorgen-nvim" },
+    }),
+}

--- a/lua/mason-registry/index.lua
+++ b/lua/mason-registry/index.lua
@@ -37,6 +37,7 @@ return {
   codelldb = "mason-registry.codelldb",
   codeql = "mason-registry.codeql",
   codespell = "mason-registry.codespell",
+  ["colorgen-nvim"] = "mason-registry.colorgen-nvim",
   commitlint = "mason-registry.commitlint",
   cpplint = "mason-registry.cpplint",
   cpptools = "mason-registry.cpptools",


### PR DESCRIPTION
Feel free to close if this is out of scope for `mason.nvim`.

I'd like to experiment with using `colorgen-nvim` to generate a colorscheme on-the-fly with a Neovim command in my configuration.

This PR adds `colorgen-nvim` as an installable package.