### PR TITLE
fix(tectonic): pin version

### DIFF
--- a/lua/mason-registry/tectonic/init.lua
+++ b/lua/mason-registry/tectonic/init.lua
@@ -3,6 +3,7 @@ local platform = require "mason-core.platform"
 local _ = require "mason-core.functional"
 local github = require "mason-core.managers.github"
 local std = require "mason-core.managers.std"
+local Optional = require "mason-core.optional"
 
 local coalesce, when = _.coalesce, _.when
 
@@ -25,14 +26,16 @@ return Pkg.new {
                 github
                     .untargz_release_file({
                         repo = repo,
+                        version = Optional.of "tectonic@0.12.0",
                         asset_file = coalesce(
-                            when(platform.is.mac, format_release_file "tectonic-%s-x86_64-apple-darwin.tar.gz"),
+                            when(platform.is.mac_x64, format_release_file "tectonic-%s-x86_64-apple-darwin.tar.gz"),
+                            when(platform.is.mac_arm64, format_release_file "tectonic-%s-aarch64-apple-darwin.tar.gz"),
                             when(
                                 platform.is.linux_x64_gnu,
                                 format_release_file "tectonic-%s-x86_64-unknown-linux-gnu.tar.gz"
                             ),
                             when(
-                                platform.is.linux_x64_musl,
+                                platform.is.linux_x64,
                                 format_release_file "tectonic-%s-x86_64-unknown-linux-musl.tar.gz"
                             ),
                             when(


### PR DESCRIPTION
This is far from ideal. This is needed because the repository hosts
multiple different projects. The current mechanism to resolve the
"latest" release is not compatible with this and may end up selecting a
release for a different project.

Closes #544.
