### PR TITLE
feat(registry): add smarty-language-server

### DIFF
--- a/lua/mason-registry/index.lua
+++ b/lua/mason-registry/index.lua
@@ -198,6 +198,7 @@ return {
   shfmt = "mason-registry.shfmt",
   ["shopify-theme-check"] = "mason-registry.shopify-theme-check",
   ["slint-lsp"] = "mason-registry.slint-lsp",
+  ["smarty-language-server"] = "mason-registry.smarty-language-server",
   solang = "mason-registry.solang",
   solargraph = "mason-registry.solargraph",
   solhint = "mason-registry.solhint",

--- a/lua/mason-registry/smarty-language-server/init.lua
+++ b/lua/mason-registry/smarty-language-server/init.lua
@@ -1,0 +1,11 @@
+local Pkg = require "mason-core.package"
+local npm = require "mason-core.managers.npm"
+
+return Pkg.new {
+    name = "smarty-language-server",
+    desc = [[Language Server Protocol implementation for Smarty.]],
+    homepage = "https://github.com/landeaux/vscode-smarty-langserver-extracted",
+    languages = { Pkg.Lang.Smarty },
+    categories = { Pkg.Cat.LSP },
+    install = npm.packages { "vscode-smarty-langserver-extracted", bin = { "smarty-language-server" } },
+}

--- a/lua/mason/mappings/language.lua
+++ b/lua/mason/mappings/language.lua
@@ -105,6 +105,7 @@ return {
   sh = { "beautysh" },
   shell = { "shfmt" },
   slint = { "slint-lsp" },
+  smarty = { "smarty-language-server" },
   solidity = { "solang", "solhint", "solidity", "solidity-ls" },
   sphinx = { "esbonio" },
   sql = { "sql-formatter", "sqlfluff", "sqlls", "sqls" },


### PR DESCRIPTION
This PR adds support for smarty-language-server.

[https://github.com/ssigwart/vscode-smarty](https://github.com/ssigwart/vscode-smarty)
[https://github.com/landeaux/vscode-smarty-langserver-extracted](https://github.com/landeaux/vscode-smarty-langserver-extracted)