### PR TITLE
feat(ui): change log line number formatting in tail output

### DIFF
--- a/lua/mason/ui/components/main/package_list.lua
+++ b/lua/mason/ui/components/main/package_list.lua
@@ -196,7 +196,11 @@ local function InstallingPackageComponent(pkg, state)
     local pkg_state = state.packages.states[pkg.name]
     local current_state = pkg_state.is_terminated and p.Comment " (cancelling)" or p.none ""
     local tail = pkg_state.short_tailed_output
-            and ("▶ (#" .. #pkg_state.tailed_output .. ") " .. pkg_state.short_tailed_output)
+            and ("▶ # [%d/%d] %s"):format(
+                #pkg_state.tailed_output,
+                #pkg_state.tailed_output,
+                pkg_state.short_tailed_output
+            )
         or ""
     return Ui.Node {
         Ui.HlTextNode {


### PR DESCRIPTION
I think this has better affordance and better indicates that the log is
truncated to a single line and can actually be expanded.
