### PR TITLE
Update the name of the binary for editorconfig-checker

### DIFF
--- a/lua/mason-registry/editorconfig-checker/init.lua
+++ b/lua/mason-registry/editorconfig-checker/init.lua
@@ -28,6 +28,6 @@ return Pkg.new {
         }
         source.with_receipt()
         local prog = source.asset_file:gsub("%.tar%.gz$", "")
-        ctx:link_bin("editorconfig-checker", path.concat { "bin", prog })
+        ctx:link_bin("ec", path.concat { "bin", prog })
     end,
 }


### PR DESCRIPTION
Changed the name of the binary for the editorconfig check linter to match what is expected by default from null ls. Currently, the name of the binary in the /bin folder does not match that. 