### PR TITLE
fix(ui): set severity min & max for namespaced diagnostic config

### DIFF
--- a/lua/mason-core/ui/display.lua
+++ b/lua/mason-core/ui/display.lua
@@ -201,7 +201,10 @@ function M.new_view_only_win(name, filetype)
     local window_opts = {}
 
     vim.diagnostic.config({
-        virtual_text = true,
+        virtual_text = {
+            severity = { min = vim.diagnostic.severity.HINT, max = vim.diagnostic.severity.ERROR },
+        },
+        right_align = false,
         underline = false,
         signs = false,
         virtual_lines = false,


### PR DESCRIPTION
Simply setting it to true won't override sub-items such as a user's severity config. Some users may for example have set the `virtual_text` severity to only show ERRORs, causing Mason's INFO diagnostics to not be displayed.