### PR TITLE
feat(dotnet/init.lua): ignore failed sources

### DIFF
--- a/lua/mason-core/managers/dotnet/init.lua
+++ b/lua/mason-core/managers/dotnet/init.lua
@@ -31,6 +31,7 @@ function M.install(pkg, opt)
     ctx.spawn.dotnet {
         "tool",
         "update",
+        "--ignore-failed-sources",
         "--tool-path",
         ".",
         ctx.requested_version

--- a/tests/mason-core/managers/dotnet_spec.lua
+++ b/tests/mason-core/managers/dotnet_spec.lua
@@ -12,6 +12,7 @@ describe("dotnet manager", function()
             assert.spy(ctx.spawn.dotnet).was_called_with {
                 "tool",
                 "update",
+                "--ignore-failed-sources",
                 "--tool-path",
                 ".",
                 { "--version", "42.13.37" },


### PR DESCRIPTION
I contract for a number of organizations and I'm never authenticated to all the private nuget feeds at once so installing tools always fails without this flag. I believe this should be a safe addition.

[Docs](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-tool-install)

`--ignore-failed-sources`

Treat package source failures as warnings.