### PR TITLE
fix(registry): change ruff-lsp category from linter to lsp

### DIFF
--- a/PACKAGES.md
+++ b/PACKAGES.md
@@ -4159,7 +4159,7 @@ Categories: `Linter`
 
 Homepage: [https://github.com/charliermarsh/ruff-lsp/](https://github.com/charliermarsh/ruff-lsp/)  
 Languages: `Python`  
-Categories: `Linter`  
+Categories: `LSP`  
 
 <details>
     <summary>History:</summary>

--- a/lua/mason-registry/ruff-lsp/init.lua
+++ b/lua/mason-registry/ruff-lsp/init.lua
@@ -6,6 +6,6 @@ return Pkg.new {
     desc = [[A Language Server Protocol implementation for Ruff - An extremely fast Python linter, written in Rust.]],
     homepage = "https://github.com/charliermarsh/ruff-lsp/",
     languages = { Pkg.Lang.Python },
-    categories = { Pkg.Cat.Linter },
+    categories = { Pkg.Cat.LSP },
     install = pip3.packages { "ruff-lsp", bin = { "ruff-lsp" } },
 }


### PR DESCRIPTION
Change `ruff-lsp` package  category to 'LSP'.