### PR TITLE
feat(registry): add cueimports

### DIFF
--- a/lua/mason-registry/cueimports/init.lua
+++ b/lua/mason-registry/cueimports/init.lua
@@ -1,0 +1,11 @@
+local Pkg = require "mason-core.package"
+local go = require "mason-core.managers.go"
+
+return Pkg.new {
+    name = "cueimports",
+    desc = [[CUE tool that updates your import lines, adding missing ones and removing unused ones.]],
+    homepage = "https://github.com/asdine/cueimports",
+    languages = { Pkg.Lang.Cue },
+    categories = { Pkg.Cat.Formatter },
+    install = go.packages { "github.com/asdine/cueimports/cmd/cueimports", bin = { "cueimports" } },
+}

--- a/lua/mason-registry/index.lua
+++ b/lua/mason-registry/index.lua
@@ -48,6 +48,7 @@ return {
   ["css-lsp"] = "mason-registry.css-lsp",
   ["cssmodules-language-server"] = "mason-registry.cssmodules-language-server",
   ["cucumber-language-server"] = "mason-registry.cucumber-language-server",
+  cueimports = "mason-registry.cueimports",
   cuelsp = "mason-registry.cuelsp",
   curlylint = "mason-registry.curlylint",
   ["dart-debug-adapter"] = "mason-registry.dart-debug-adapter",

--- a/lua/mason/mappings/language.lua
+++ b/lua/mason/mappings/language.lua
@@ -28,7 +28,7 @@ return {
   csh = { "beautysh" },
   css = { "css-lsp", "cssmodules-language-server", "prettier", "prettierd", "tailwindcss-language-server" },
   cucumber = { "cucumber-language-server" },
-  cue = { "cuelsp" },
+  cue = { "cueimports", "cuelsp" },
   d = { "serve-d" },
   dart = { "dart-debug-adapter" },
   dhall = { "dhall-lsp" },


### PR DESCRIPTION
`cueimports` is a newish tool for automatically managing imports for the CUE language.