### PR TITLE
Support aarch64 (arm64)

### DIFF
--- a/lua/mason-registry/clangd/init.lua
+++ b/lua/mason-registry/clangd/init.lua
@@ -24,6 +24,7 @@ return Pkg.new {
                 local target = coalesce(
                     when(platform.is.mac, "clangd-mac-%s.zip"),
                     when(platform.is.linux_x64, "clangd-linux-%s.zip"),
+                    when(platform.is.linux_arm64, "clangd-linux-%s.zip"),
                     when(platform.is.win_x64, "clangd-windows-%s.zip")
                 )
                 return target and target:format(release)


### PR DESCRIPTION
This patch fixes installation of aarch64 (e.g. Raspberry Pi with 64bit OS)