### PR TITLE
fix(powershell): terminate stdin with newline

### DIFF
--- a/lua/mason-core/managers/powershell/init.lua
+++ b/lua/mason-core/managers/powershell/init.lua
@@ -28,6 +28,7 @@ function M.script(script, opts, custom_spawn)
             async_uv.write(stdin, PWSHOPT.progress_preference)
             async_uv.write(stdin, PWSHOPT.security_protocol)
             async_uv.write(stdin, script)
+            async_uv.write(stdin, "\n")
             async_uv.shutdown(stdin)
             async_uv.close(stdin)
         end),

--- a/tests/mason-core/managers/powershell_spec.lua
+++ b/tests/mason-core/managers/powershell_spec.lua
@@ -76,7 +76,7 @@ describe("powershell manager", function()
         powershell().script "echo 'Is this bash?'"
 
         assert.spy(spawn.pwsh).was_called(1)
-        assert.spy(vim.loop.write).was_called(4)
+        assert.spy(vim.loop.write).was_called(5)
         assert
             .spy(vim.loop.write)
             .was_called_with(match.is_ref(stdin), [[ $ErrorActionPreference = "Stop"; ]], match.is_function())
@@ -89,6 +89,7 @@ describe("powershell manager", function()
             match.is_function()
         )
         assert.spy(vim.loop.write).was_called_with(match.is_ref(stdin), "echo 'Is this bash?'", match.is_function())
+        assert.spy(vim.loop.write).was_called_with(match.is_ref(stdin), "\n", match.is_function())
         assert.spy(vim.loop.shutdown).was_called(1)
         assert.spy(vim.loop.shutdown).was_called_with(match.is_ref(stdin), match.is_function())
     end)


### PR DESCRIPTION
Powershell doesn't seem to be closing the process after commands finsh
executing and stdin is closed, not entirely sure why. This seems to fix
the issue.