### PR TITLE
feat(registry): add python-lsp-ruff

### DIFF
--- a/lua/mason-registry/index.lua
+++ b/lua/mason-registry/index.lua
@@ -179,6 +179,7 @@ return {
   ["pyproject-flake8"] = "mason-registry.pyproject-flake8",
   pyre = "mason-registry.pyre",
   pyright = "mason-registry.pyright",
+  ["python-lsp-ruff"] = "mason-registry.python-lsp-ruff",
   ["python-lsp-server"] = "mason-registry.python-lsp-server",
   ["quick-lint-js"] = "mason-registry.quick-lint-js",
   ["r-languageserver"] = "mason-registry.r-languageserver",

--- a/lua/mason-registry/python-lsp-ruff/init.lua
+++ b/lua/mason-registry/python-lsp-ruff/init.lua
@@ -1,0 +1,11 @@
+local Pkg = require "mason-core.package"
+local pip3 = require "mason-core.managers.pip3"
+
+return Pkg.new {
+    name = "python-lsp-ruff",
+    desc = [[Python-lsp-server linter plugin based on ruff - An extremely fast Python linter, written in Rust.]],
+    homepage = "https://github.com/python-lsp/python-lsp-ruff",
+    languages = { Pkg.Lang.Python },
+    categories = { Pkg.Cat.Linter },
+    install = pip3.packages { "python-lsp-ruff", bin = { "python-lsp-ruff" } },
+}

--- a/lua/mason/mappings/language.lua
+++ b/lua/mason/mappings/language.lua
@@ -95,7 +95,7 @@ return {
   protobuf = { "buf", "buf-language-server", "protolint" },
   puppet = { "puppet-editor-services" },
   purescript = { "purescript-language-server" },
-  python = { "autoflake", "autopep8", "black", "blue", "debugpy", "flake8", "isort", "jedi-language-server", "mypy", "pydocstyle", "pylama", "pylint", "pyproject-flake8", "pyre", "pyright", "python-lsp-server", "reorder-python-imports", "rstcheck", "ruff", "ruff-lsp", "semgrep", "sourcery", "usort", "vulture", "yapf" },
+  python = { "autoflake", "autopep8", "black", "blue", "debugpy", "flake8", "isort", "jedi-language-server", "mypy", "pydocstyle", "pylama", "pylint", "pyproject-flake8", "pyre", "pyright", "python-lsp-ruff", "python-lsp-server", "reorder-python-imports", "rstcheck", "ruff", "ruff-lsp", "semgrep", "sourcery", "usort", "vulture", "yapf" },
   r = { "r-languageserver" },
   reason = { "reason-language-server" },
   rescript = { "rescript-lsp" },


### PR DESCRIPTION
Enable installation of the python-lsp-server ruff extension.