### PR TITLE
feat(registry): add fennel-ls

### DIFF
--- a/PACKAGES.md
+++ b/PACKAGES.md
@@ -76,6 +76,7 @@
 - [eslint-lsp](#eslint-lsp)
 - [eslint_d](#eslint_d)
 - [fantomas](#fantomas)
+- [fennel-ls](#fennel-ls)
 - [firefox-debug-adapter](#firefox-debug-adapter)
 - [fixjson](#fixjson)
 - [flake8](#flake8)
@@ -1760,6 +1761,18 @@ Categories: `Formatter`
 
 ```
 :MasonInstall fantomas
+```
+
+# fennel-ls
+
+> fennel-ls is a language server for the fennel language
+
+Homepage: [https://sr.ht/~xerool/fennel-ls](https://sr.ht/~xerool/fennel-ls)  
+Languages: `Fennel`  
+Categories: `LSP`  
+
+```
+:MasonInstall fennel-ls
 ```
 
 

--- a/lua/mason-registry/fennel-ls/init.lua
+++ b/lua/mason-registry/fennel-ls/init.lua
@@ -1,0 +1,17 @@
+local Pkg = require "mason-core.package"
+local _ = require "mason-core.functional"
+local git = require "mason-core.managers.git"
+
+return Pkg.new {
+    name = "fennel-ls",
+    desc = [[Fennel language server]],
+    languages = { Pkg.Lang.Fennel },
+    categories = { Pkg.Cat.LSP },
+    homepage = "https://sr.ht/~xerool/fennel-ls",
+    ---@async
+    ---@param ctx InstallContext
+    install = function(ctx)
+        git.clone({ "https://git.sr.ht/~xerool/fennel-ls" }).with_receipt()
+        ctx.spawn.make {}
+    end,
+}

--- a/lua/mason-registry/index.lua
+++ b/lua/mason-registry/index.lua
@@ -75,6 +75,7 @@ return {
   ["eslint-lsp"] = "mason-registry.eslint-lsp",
   eslint_d = "mason-registry.eslint_d",
   fantomas = "mason-registry.fantomas",
+  ["fennel-ls"] = "mason-registry.fennel-ls",
   ["firefox-debug-adapter"] = "mason-registry.firefox-debug-adapter",
   fixjson = "mason-registry.fixjson",
   flake8 = "mason-registry.flake8",

--- a/lua/mason/mappings/language.lua
+++ b/lua/mason/mappings/language.lua
@@ -42,6 +42,7 @@ return {
   erg = { "erg-language-server" },
   erlang = { "erlang-ls" },
   ["f#"] = { "fantomas", "fsautocomplete", "netcoredbg" },
+  fennel = { "fennel-ls" },
   flow = { "prettier", "prettierd" },
   flux = { "flux-lsp" },
   fortran = { "fortls" },


### PR DESCRIPTION
Closes #867

This PR adds support for the fennel language server.

It's repo is [here](https://sr.ht/~xerool/fennel-ls)
And `nvim-lspconfig`'s entry on it is [here](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#fennel-ls)

One problem with this implementation is that it relies on the presence of `make` in the user's system. This is probably a safe bet on unix systems, but not on windows systems. Are there any suggestions on how to handle this?