### PR TITLE
refactor(providers): remove ?include_prerelease query param

### DIFF
--- a/lua/mason-core/managers/github/client.lua
+++ b/lua/mason-core/managers/github/client.lua
@@ -55,15 +55,11 @@ function M.fetch_release(repo, tag_name)
     end)
 end
 
----@alias FetchLatestGithubReleaseOpts {include_prerelease: boolean}
-
 ---@async
 ---@param repo string The GitHub repo ("username/repo").
----@param opts FetchLatestGithubReleaseOpts?
 ---@return Result # Result<GitHubRelease>
-function M.fetch_latest_release(repo, opts)
-    opts = opts or { include_prerelease = false }
-    return providers.github.get_latest_release(repo, { include_prerelease = opts.include_prerelease })
+function M.fetch_latest_release(repo)
+    return providers.github.get_latest_release(repo)
 end
 
 ---@async

--- a/lua/mason-core/providers/init.lua
+++ b/lua/mason-core/providers/init.lua
@@ -7,7 +7,7 @@ local Result = require "mason-core.result"
 ---@alias GitHubTag { name: string }
 
 ---@class GitHubProvider
----@field get_latest_release? async fun(repo: string, opts?: { include_prerelease?: boolean }): Result # Result<GitHubRelease>
+---@field get_latest_release? async fun(repo: string): Result # Result<GitHubRelease>
 ---@field get_all_release_versions? async fun(repo: string): Result # Result<string[]>
 ---@field get_latest_tag? async fun(repo: string): Result # Result<GitHubTag>
 ---@field get_all_tags? async fun(repo: string): Result # Result<string[]>

--- a/lua/mason-registry/vls/init.lua
+++ b/lua/mason-registry/vls/init.lua
@@ -17,12 +17,9 @@ return Pkg.new {
     install = function(ctx)
         local repo = "vlang/vls"
 
-        ---@type GitHubRelease
-        local latest_dev_build = github_client.fetch_latest_release(repo, { include_prerelease = true }):get_or_throw()
-
         github
             .download_release_file({
-                version = Optional.of(latest_dev_build.tag_name),
+                version = Optional.of "latest",
                 repo = repo,
                 out_file = platform.is.win and "vls.exe" or "vls",
                 asset_file = _.coalesce(

--- a/lua/mason/providers/client/gh.lua
+++ b/lua/mason/providers/client/gh.lua
@@ -1,27 +1,14 @@
 local spawn = require "mason-core.spawn"
 local _ = require "mason-core.functional"
 local Result = require "mason-core.result"
-local Optional = require "mason-core.optional"
 
 ---@type GitHubProvider
 return {
-    get_latest_release = function(repo, opts)
-        opts = opts or {}
-        if not opts.include_prerelease then
-            return spawn
-                .gh({ "api", ("repos/%s/releases/latest"):format(repo) })
-                :map(_.prop "stdout")
-                :map_catching(vim.json.decode)
-        else
-            return spawn
-                .gh({ "api", ("repos/%s/releases"):format(repo) })
-                :map(_.prop "stdout")
-                :map_catching(vim.json.decode)
-                :map(_.find_first(_.prop_eq("draft", false)))
-                :and_then(function(release)
-                    return Optional.of_nilable(release):ok_or "Failed to find latest release."
-                end)
-        end
+    get_latest_release = function(repo)
+        return spawn
+            .gh({ "api", ("repos/%s/releases/latest"):format(repo) })
+            :map(_.prop "stdout")
+            :map_catching(vim.json.decode)
     end,
     get_all_release_versions = function(repo)
         return spawn

--- a/lua/mason/providers/registry-api/init.lua
+++ b/lua/mason/providers/registry-api/init.lua
@@ -3,13 +3,8 @@ local api = require "mason-registry.api"
 ---@type Provider
 return {
     github = {
-        get_latest_release = function(repo, opts)
-            opts = opts or {}
-            return api.repo.releases.latest({ repo = repo }, {
-                params = {
-                    include_prerelease = (opts and opts.include_prerelease) and "true" or "false",
-                },
-            })
+        get_latest_release = function(repo)
+            return api.repo.releases.latest { repo = repo }
         end,
         get_all_release_versions = function(repo)
             return api.repo.releases.all { repo = repo }


### PR DESCRIPTION
This is no longer supported by mason-registry-api.
