### PR TITLE
feat: add buffer name

### DIFF
--- a/lua/mason-core/ui/display.lua
+++ b/lua/mason-core/ui/display.lua
@@ -394,6 +394,7 @@ function M.new_view_only_win(name, filetype)
         for key, value in pairs(buf_opts) do
             vim.api.nvim_buf_set_option(bufnr, key, value)
         end
+        vim.api.nvim_buf_set_name(bufnr, "Mason")
 
         vim.cmd [[ syntax clear ]]
 


### PR DESCRIPTION
This is a simple change to make the buffer used by mason have a specific name.

The reason for this change is that I use a voice coding system that relies on reading out window titles to establish a specific context to enable and disable certain command grammars, and for plugin specific windows the easiest way to differentiate is to use the buffer name which can be placed into the vim title.