### PR TITLE
fix: avoid calling API functions inside fast event

### DIFF
--- a/lua/mason-registry/fourmolu/init.lua
+++ b/lua/mason-registry/fourmolu/init.lua
@@ -13,17 +13,19 @@ return Pkg.new {
     ---@async
     ---@param ctx InstallContext
     install = function(ctx)
+        ---@param template string
+        local function release_file(template_string)
+            return _.compose(_.format(template_string), _.gsub("^v", ""))
+        end
+
         github
             .download_release_file({
                 repo = "fourmolu/fourmolu",
                 out_file = "fourmolu",
-                asset_file = function(version)
-                    local target = _.coalesce(
-                        _.when(platform.is.mac_x64, "fourmolu-%s-osx-x86_64"),
-                        _.when(platform.is.linux_x64_gnu, "fourmolu-%s-linux-x86_64")
-                    )
-                    return target and target:format(version:gsub("^v", ""))
-                end,
+                asset_file = _.coalesce(
+                    _.when(platform.is.mac_x64, release_file "fourmolu-%s-osx-x86_64"),
+                    _.when(platform.is.linux_x64_gnu, release_file "fourmolu-%s-linux-x86_64")
+                ),
             })
             .with_receipt()
         std.chmod("+x", { "fourmolu" })

--- a/lua/mason-registry/lua-language-server/init.lua
+++ b/lua/mason-registry/lua-language-server/init.lua
@@ -18,18 +18,14 @@ return Pkg.new {
         github
             .unzip_release_file({
                 repo = "sumneko/vscode-lua",
-                asset_file = function(version)
-                    local target = coalesce(
-                        when(platform.is.mac_x64, "vscode-lua-%s-darwin-x64.vsix"),
-                        when(platform.is.mac_arm64, "vscode-lua-%s-darwin-arm64.vsix"),
-                        when(platform.is.linux_x64_gnu, "vscode-lua-%s-linux-x64.vsix"),
-                        when(platform.is.linux_arm64_gnu, "vscode-lua-%s-linux-arm64.vsix"),
-                        when(platform.is.win_x64, "vscode-lua-%s-win32-x64.vsix"),
-                        when(platform.is.win_x86, "vscode-lua-%s-win32-ia32.vsix")
-                    )
-
-                    return target and target:format(version)
-                end,
+                asset_file = coalesce(
+                    when(platform.is.mac_x64, _.format "vscode-lua-%s-darwin-x64.vsix"),
+                    when(platform.is.mac_arm64, _.format "vscode-lua-%s-darwin-arm64.vsix"),
+                    when(platform.is.linux_x64_gnu, _.format "vscode-lua-%s-linux-x64.vsix"),
+                    when(platform.is.linux_arm64_gnu, _.format "vscode-lua-%s-linux-arm64.vsix"),
+                    when(platform.is.win_x64, _.format "vscode-lua-%s-win32-x64.vsix"),
+                    when(platform.is.win_x86, _.format "vscode-lua-%s-win32-ia32.vsix")
+                ),
             })
             .with_receipt()
 


### PR DESCRIPTION
This won't be a problem once https://github.com/mason-org/mason-registry
is integrated because package installations won't independently execute
code.

Fixes #891.
