### PR TITLE
feat(registry): add drools-lsp

### DIFF
--- a/lua/mason-registry/drools-lsp/init.lua
+++ b/lua/mason-registry/drools-lsp/init.lua
@@ -1,0 +1,71 @@
+--[[
+Configuration:
+
+-- You can use the Mason-generated shell execution wrapper:
+require("lspconfig").drools_lsp.setup {
+    capabilities = capabilities,
+    on_attach = on_attach,
+    cmd = { 'drools-lsp' },
+}
+
+-- or you can specify the path to the Mason-installed drools jar file (allowing you to also specify java settings):
+local util = require "lspconfig.util"
+local reg = require "mason-registry"
+local jar = "drools-lsp-server-jar-with-dependencies.jar"
+require("lspconfig").drools_lsp.setup {
+    capabilities = capabilities,
+    on_attach = on_attach,
+    settings = {
+        -- optional
+        java = {
+            bin = "/path/to/java",
+            opts = { "-Xmx500m" },
+        },
+        -- required
+        drools = {
+            jar = util.path.join(reg.get_package("drools-lsp"):get_install_path(), jar),
+            -- the above is *currently* equivalent to the below (but path below could change in the future)
+            -- jar = vim.fn.stdpath "data" .. "/mason/packages/drools-lsp/" .. jar,
+        },
+    },
+}
+
+-- or you can use any of the other configuration options listed here:
+https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#drools_lsp
+--]]
+
+local Pkg = require "mason-core.package"
+local github = require "mason-core.managers.github"
+local Optional = require "mason-core.optional"
+local path = require "mason-core.path"
+
+local name = "drools-lsp"
+local repo = "kiegroup/" .. name
+local file = name .. "-server-jar-with-dependencies.jar"
+
+return Pkg.new {
+    name = name,
+    desc = [[An implementation of a language server for the Drools Rule Language.]],
+    homepage = "https://github.com/" .. repo,
+    languages = { Pkg.Lang.Drools },
+    categories = { Pkg.Cat.LSP },
+    ---@async
+    ---@param ctx InstallContext
+    install = function(ctx)
+        github
+            .download_release_file({
+                repo = repo,
+                version = Optional.of "latest",
+                asset_file = file,
+                out_file = file,
+            })
+            .with_receipt()
+        ctx:link_bin(
+            name,
+            ctx:write_shell_exec_wrapper(
+                name,
+                ("java -cp %q org.drools.lsp.server.Main"):format(path.concat { ctx.package:get_install_path(), file })
+            )
+        )
+    end,
+}

--- a/lua/mason-registry/drools-lsp/init.lua
+++ b/lua/mason-registry/drools-lsp/init.lua
@@ -1,70 +1,31 @@
---[[
-Configuration:
-
--- You can use the Mason-generated shell execution wrapper:
-require("lspconfig").drools_lsp.setup {
-    capabilities = capabilities,
-    on_attach = on_attach,
-    cmd = { 'drools-lsp' },
-}
-
--- or you can specify the path to the Mason-installed drools jar file (allowing you to also specify java settings):
-local util = require "lspconfig.util"
-local reg = require "mason-registry"
-local jar = "drools-lsp-server-jar-with-dependencies.jar"
-require("lspconfig").drools_lsp.setup {
-    capabilities = capabilities,
-    on_attach = on_attach,
-    settings = {
-        -- optional
-        java = {
-            bin = "/path/to/java",
-            opts = { "-Xmx500m" },
-        },
-        -- required
-        drools = {
-            jar = util.path.join(reg.get_package("drools-lsp"):get_install_path(), jar),
-            -- the above is *currently* equivalent to the below (but path below could change in the future)
-            -- jar = vim.fn.stdpath "data" .. "/mason/packages/drools-lsp/" .. jar,
-        },
-    },
-}
-
--- or you can use any of the other configuration options listed here:
-https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#drools_lsp
---]]
-
 local Pkg = require "mason-core.package"
 local github = require "mason-core.managers.github"
 local Optional = require "mason-core.optional"
 local path = require "mason-core.path"
 
-local name = "drools-lsp"
-local repo = "kiegroup/" .. name
-local file = name .. "-server-jar-with-dependencies.jar"
-
 return Pkg.new {
-    name = name,
+    name = "drools-lsp",
     desc = [[An implementation of a language server for the Drools Rule Language.]],
-    homepage = "https://github.com/" .. repo,
+    homepage = "https://github.com/kiegroup/drools-lsp",
     languages = { Pkg.Lang.Drools },
     categories = { Pkg.Cat.LSP },
     ---@async
     ---@param ctx InstallContext
     install = function(ctx)
+        local jar = "drools-lsp-server-jar-with-dependencies.jar"
         github
             .download_release_file({
-                repo = repo,
+                repo = "kiegroup/drools-lsp",
                 version = Optional.of "latest",
-                asset_file = file,
-                out_file = file,
+                asset_file = jar,
+                out_file = jar,
             })
             .with_receipt()
         ctx:link_bin(
-            name,
+            "drools-lsp",
             ctx:write_shell_exec_wrapper(
-                name,
-                ("java -cp %q org.drools.lsp.server.Main"):format(path.concat { ctx.package:get_install_path(), file })
+                "drools-lsp",
+                ("java -cp %q org.drools.lsp.server.Main"):format(path.concat { ctx.package:get_install_path(), jar })
             )
         )
     end,

--- a/lua/mason-registry/index.lua
+++ b/lua/mason-registry/index.lua
@@ -61,6 +61,7 @@ return {
   ["dockerfile-language-server"] = "mason-registry.dockerfile-language-server",
   ["dot-language-server"] = "mason-registry.dot-language-server",
   dprint = "mason-registry.dprint",
+  ["drools-lsp"] = "mason-registry.drools-lsp",
   ["editorconfig-checker"] = "mason-registry.editorconfig-checker",
   efm = "mason-registry.efm",
   ["elixir-ls"] = "mason-registry.elixir-ls",

--- a/lua/mason/mappings/language.lua
+++ b/lua/mason/mappings/language.lua
@@ -35,6 +35,7 @@ return {
   django = { "curlylint", "djlint" },
   dockerfile = { "dockerfile-language-server", "hadolint" },
   dot = { "dot-language-server" },
+  drools = { "drools-lsp" },
   elixir = { "elixir-ls" },
   elm = { "elm-format", "elm-language-server" },
   ember = { "ember-language-server" },


### PR DESCRIPTION
This PR adds support for Red Hat's [Drools Rule Language](https://docs.drools.org/latest/drools-docs/docs-website/drools/language-reference/index.html#con-drl_drl-rules) (ft=`drools`, ext=`.drl`). The [drools-lsp](https://github.com/kiegroup/drools-lsp/) server config was recently merged into [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig) (also written by me). The generated doc link in nvim-lspconfig is [here](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#drools_lsp).

The companion PR in mason-lspconfig.nvim is [here](https://github.com/williamboman/mason-lspconfig.nvim/pull/125).

_Thank you so much!_


Signed-off-by: David Ward <dward@redhat.com>