### PR TITLE
fix(crystalline): update linux asset name

### DIFF
--- a/lua/mason-registry/crystalline/init.lua
+++ b/lua/mason-registry/crystalline/init.lua
@@ -20,7 +20,7 @@ return Pkg.new {
                 repo = "elbywan/crystalline",
                 asset_file = coalesce(
                     when(platform.is.mac_x64, "crystalline_x86_64-apple-darwin.gz"),
-                    when(platform.is.linux_x64, "crystalline_x86_64-unknown-linux-gnu.gz")
+                    when(platform.is.linux_x64, "crystalline_x86_64-unknown-linux-musl.gz")
                 ),
                 out_file = "crystalline",
             })


### PR DESCRIPTION
CI failed at https://github.com/mason-org/mason-registry/pull/305
