### PR TITLE
feat(ui): customizable window height and width

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ Example:
 ```lua
 require("mason").setup({
     ui = {
+        height = 0.8,
+        width = 60,
         icons = {
             package_installed = "✓",
             package_pending = "➜",
@@ -205,6 +207,12 @@ local DEFAULT_SETTINGS = {
 
         -- The border to use for the UI window. Accepts same border values as |nvim_open_win()|.
         border = "none",
+
+        -- Width of the window, accepts integer (fixed width) or float (percentage of screen width).
+        width = 0.8,
+
+        -- Height of the window, accepts integer (fixed height) or float (percentage of screen height).
+        height = 0.8,
 
         icons = {
             -- The list icon to use for installed packages.

--- a/doc/mason.txt
+++ b/doc/mason.txt
@@ -218,6 +218,8 @@ Example:
 >lua
     require("mason").setup({
         ui = {
+            height = 0.8,   -- 0.8 * (vim.o.lines - vim.o.cmdheight)
+            width = 60,     -- 60 columns
             icons = {
                 package_installed = "✓",
                 package_pending = "➜",

--- a/lua/mason-core/ui/display.lua
+++ b/lua/mason-core/ui/display.lua
@@ -1,5 +1,6 @@
 local log = require "mason-core.log"
 local state = require "mason-core.ui.state"
+local settings = require "mason.settings"
 
 local M = {}
 
@@ -170,19 +171,29 @@ M._render_node = render_node
 ---@param opts WindowOpts
 ---@param sizes_only boolean Whether to only return properties that control the window size.
 local function create_popup_window_opts(opts, sizes_only)
+    local lines = vim.o.lines - vim.o.cmdheight
     local columns = vim.o.columns
-    local top_offset = 1
-    local bottom_offset = 1 + vim.o.cmdheight
-    if vim.o.laststatus == 0 then
-        bottom_offset = math.max(bottom_offset - 1, 1)
-    end
-    local height = vim.o.lines - bottom_offset - top_offset
-    local width = math.floor(columns * 0.8)
+    local height = (type(settings.current.ui.height) == 'number'    -- fixed width
+                    and math.floor(settings.current.ui.height) == settings.current.ui.height
+                    and settings.current.ui.height) or
+                   (type(settings.current.ui.height) == 'number'    -- percentage width
+                    and math.floor(settings.current.ui.height) == 0
+                    and math.ceil(lines * settings.current.ui.height)) or
+                   math.ceil(lines * 0.8)
+    local width = (type(settings.current.ui.width) == 'number'     -- fixed width
+                   and math.floor(settings.current.ui.width) == settings.current.ui.width
+                   and settings.current.ui.width) or
+                  (type(settings.current.ui.width) == 'number'      -- percentage width
+                   and math.floor(settings.current.ui.width) == 0
+                   and math.ceil(columns * settings.current.ui.width)) or
+                  math.ceil(columns * 0.8)
+    local row = math.floor((lines - height) / 2)
+    local col = math.floor((columns - width) / 2)
     local popup_layout = {
         height = height,
         width = width,
-        row = top_offset,
-        col = math.floor((columns - width) / 2),
+        row = row,
+        col = col,
         relative = "editor",
         style = "minimal",
         zindex = 45,

--- a/lua/mason-core/ui/display.lua
+++ b/lua/mason-core/ui/display.lua
@@ -168,25 +168,22 @@ M._render_node = render_node
 
 ---@alias WindowOpts { effects?: table<string, fun()>, winhighlight?: string[], border?: string|table }
 
+---@param size integer | float
+---@param viewport integer
+local function calc_size(size, viewport)
+    if size <= 1 then
+        return math.ceil(size * viewport)
+    end
+    return math.min(size, viewport)
+end
+
 ---@param opts WindowOpts
 ---@param sizes_only boolean Whether to only return properties that control the window size.
 local function create_popup_window_opts(opts, sizes_only)
     local lines = vim.o.lines - vim.o.cmdheight
     local columns = vim.o.columns
-    local height = (type(settings.current.ui.height) == 'number'    -- fixed width
-                    and math.floor(settings.current.ui.height) == settings.current.ui.height
-                    and settings.current.ui.height) or
-                   (type(settings.current.ui.height) == 'number'    -- percentage width
-                    and math.floor(settings.current.ui.height) == 0
-                    and math.ceil(lines * settings.current.ui.height)) or
-                   math.ceil(lines * 0.8)
-    local width = (type(settings.current.ui.width) == 'number'     -- fixed width
-                   and math.floor(settings.current.ui.width) == settings.current.ui.width
-                   and settings.current.ui.width) or
-                  (type(settings.current.ui.width) == 'number'      -- percentage width
-                   and math.floor(settings.current.ui.width) == 0
-                   and math.ceil(columns * settings.current.ui.width)) or
-                  math.ceil(columns * 0.8)
+    local height = calc_size(settings.current.ui.height, lines)
+    local width = calc_size(settings.current.ui.width, columns)
     local row = math.floor((lines - height) / 2)
     local col = math.floor((columns - width) / 2)
     local popup_layout = {

--- a/lua/mason/settings.lua
+++ b/lua/mason/settings.lua
@@ -58,11 +58,15 @@ local DEFAULT_SETTINGS = {
         -- The border to use for the UI window. Accepts same border values as |nvim_open_win()|.
         border = "none",
 
-        -- Width of the window, accepts integer (fixed width) or float (percentage of screen width).
+        -- Width of the window. Accepts:
+        -- - Integer greater than 1 for fixed width.
+        -- - Float in the range of 0-1 for a percentage of screen width.
         width = 0.8,
 
-        -- Height of the window, accepts integer (fixed height) or float (percentage of screen height).
-        height = 0.8,
+        -- Height of the window. Accepts:
+        -- - Integer greater than 1 for fixed height.
+        -- - Float in the range of 0-1 for a percentage of screen height.
+        height = 0.9,
 
         icons = {
             -- The list icon to use for installed packages.

--- a/lua/mason/settings.lua
+++ b/lua/mason/settings.lua
@@ -58,6 +58,12 @@ local DEFAULT_SETTINGS = {
         -- The border to use for the UI window. Accepts same border values as |nvim_open_win()|.
         border = "none",
 
+        -- Width of the window, accepts integer (fixed width) or float (percentage of screen width).
+        width = 0.8,
+
+        -- Height of the window, accepts integer (fixed height) or float (percentage of screen height).
+        height = 0.8,
+
         icons = {
             -- The list icon to use for installed packages.
             package_installed = "◍",


### PR DESCRIPTION
Allow user to customize their window height and width.

Also tweaks the default height and width so it looks better when `cmdheight` is 0:

Before this commit:

![image](https://user-images.githubusercontent.com/76579810/212493750-fa203fcb-71d1-4bed-8bbe-160d746e1983.png)


After this commit:

![image](https://user-images.githubusercontent.com/76579810/212493715-c4d9f9a5-5c72-4248-b53b-7338f118891e.png)