### PR TITLE
fix(drools-lsp): leverage simpler -jar syntax now that drools-lsp supports it

### DIFF
--- a/lua/mason-registry/drools-lsp/init.lua
+++ b/lua/mason-registry/drools-lsp/init.lua
@@ -25,7 +25,7 @@ return Pkg.new {
             "drools-lsp",
             ctx:write_shell_exec_wrapper(
                 "drools-lsp",
-                ("java -cp %q org.drools.lsp.server.Main"):format(path.concat { ctx.package:get_install_path(), jar })
+                "java -jar " .. path.concat { ctx.package:get_install_path(), jar }
             )
         )
     end,

--- a/lua/mason-registry/drools-lsp/init.lua
+++ b/lua/mason-registry/drools-lsp/init.lua
@@ -25,7 +25,7 @@ return Pkg.new {
             "drools-lsp",
             ctx:write_shell_exec_wrapper(
                 "drools-lsp",
-                "java -jar " .. path.concat { ctx.package:get_install_path(), jar }
+                ("java -jar %q"):format(path.concat { ctx.package:get_install_path(), jar })
             )
         )
     end,


### PR DESCRIPTION
fix(drools-lsp): leverage simpler -jar syntax now that drools-lsp supports it

[This PR](https://github.com/kiegroup/drools-lsp/pull/7) in `kiegroup/drools-lsp` was merged and a new release was built, making this PR doable.

Signed-off-by: David Ward <dward@redhat.com>