### PR TITLE
feat(windows): manually decompress zstd archives before untar

### DIFF
--- a/lua/mason-core/managers/github/init.lua
+++ b/lua/mason-core/managers/github/init.lua
@@ -132,7 +132,7 @@ M.unzip_release_file = release_file_processor("archive.zip", function()
 end)
 
 M.untarzst_release_file = release_file_processor("archive.tar.zst", function(opts)
-    std.untar("archive.tar.zst", { strip_components = opts.strip_components })
+    std.untarzst("archive.tar.zst", { strip_components = opts.strip_components })
 end)
 
 M.untarxz_release_file = release_file_processor("archive.tar.xz", function(opts)

--- a/lua/mason-core/managers/std/init.lua
+++ b/lua/mason-core/managers/std/init.lua
@@ -98,7 +98,7 @@ end
 
 ---@async
 ---@param file string
----@param opts {strip_components:integer}?
+---@param opts { strip_components?: integer }?
 function M.untar(file, opts)
     opts = opts or {}
     local ctx = installer.context()
@@ -111,7 +111,7 @@ function M.untar(file, opts)
             tarfile,
             file,
         }
-    end       
+    end
     ctx.spawn.tar {
         opts.strip_components and { "--strip-components", opts.strip_components } or vim.NIL,
         "--no-same-owner",
@@ -125,7 +125,25 @@ end
 
 ---@async
 ---@param file string
----@param opts {strip_components: integer?}?
+---@param opts { strip_components?: integer }?
+function M.untarzst(file, opts)
+    opts = opts or {}
+    platform.when {
+        unix = function()
+            M.untar(file, opts)
+        end,
+        win = function()
+            local ctx = installer.context()
+            local uncompressed_tar = file:gsub("%.zst$", "")
+            ctx.spawn.zstd { "-dfo", uncompressed_tar, file }
+            M.untar(uncompressed_tar, opts)
+        end,
+    }
+end
+
+---@async
+---@param file string
+---@param opts { strip_components?: integer }?
 function M.untarxz(file, opts)
     opts = opts or {}
     local ctx = installer.context()
@@ -136,7 +154,7 @@ function M.untarxz(file, opts)
         win = function()
             Result.run_catching(function()
                 win_decompress(file) -- unpack .tar.xz to .tar
-                local uncompressed_tar = file:gsub(".xz$", "")
+                local uncompressed_tar = file:gsub("%.xz$", "")
                 M.untar(uncompressed_tar, opts)
             end):recover(function()
                 ctx.spawn.arc {

--- a/lua/mason-core/managers/std/init.lua
+++ b/lua/mason-core/managers/std/init.lua
@@ -102,11 +102,21 @@ end
 function M.untar(file, opts)
     opts = opts or {}
     local ctx = installer.context()
+    local tarfile = string.gsub(file, ".zst$", "")
+    if platform.is.win and file ~= tarfile then
+        ctx.spawn.zstd {
+            "-d",
+            "-f",
+            "-o",
+            tarfile,
+            file,
+        }
+    end       
     ctx.spawn.tar {
         opts.strip_components and { "--strip-components", opts.strip_components } or vim.NIL,
         "--no-same-owner",
         "-xvf",
-        file,
+        tarfile,
     }
     pcall(function()
         ctx.fs:unlink(file)


### PR DESCRIPTION
For windows platform it will use zstd first as the windows tar implementation hangs.

Fixes #947.