### PR TITLE
feat(lua-language-server): update source repo

### DIFF
--- a/lua/mason-registry/lua-language-server/init.lua
+++ b/lua/mason-registry/lua-language-server/init.lua
@@ -8,29 +8,28 @@ local coalesce, when = _.coalesce, _.when
 
 return Pkg.new {
     name = "lua-language-server",
-    desc = [[Lua Language Server]],
+    desc = [[A language server that offers Lua language support - programmed in Lua.]],
     languages = { Pkg.Lang.Lua },
     categories = { Pkg.Cat.LSP },
     homepage = "https://github.com/LuaLS/lua-language-server",
     ---@async
     ---@param ctx InstallContext
     install = function(ctx)
-        github
-            .unzip_release_file({
-                repo = "LuaLS/lua-language-server",
-                asset_file = coalesce(
-                    when(platform.is.mac_x64, _.format "lua-language-server-%s-darwin-x64.tar.gz"),
-                    when(platform.is.mac_arm64, _.format "lua-language-server-%s-darwin-arm64.tar.gz"),
-                    when(platform.is.linux_x64_gnu, _.format "lua-language-server-%s-linux-x64.tar.gz"),
-                    when(platform.is.linux_arm64_gnu, _.format "lua-language-server-%s-linux-arm64.tar.gz"),
-                    when(platform.is.win_x64, _.format "lua-language-server-%s-win32-x64.zip"),
-                    when(platform.is.win_x86, _.format "lua-language-server-%s-win32-ia32.zip")
-                ),
-            })
-            .with_receipt()
-
+        local repo = "LuaLS/lua-language-server"
         platform.when {
             unix = function()
+                github
+                    .untargz_release_file({
+                        repo = repo,
+                        asset_file = coalesce(
+                            when(platform.is.mac_x64, _.format "lua-language-server-%s-darwin-x64.tar.gz"),
+                            when(platform.is.mac_arm64, _.format "lua-language-server-%s-darwin-arm64.tar.gz"),
+                            when(platform.is.linux_x64_gnu, _.format "lua-language-server-%s-linux-x64.tar.gz"),
+                            when(platform.is.linux_arm64_gnu, _.format "lua-language-server-%s-linux-arm64.tar.gz")
+                        ),
+                    })
+                    .with_receipt()
+
                 ctx:link_bin(
                     "lua-language-server",
                     ctx:write_exec_wrapper(
@@ -43,6 +42,15 @@ return Pkg.new {
                 )
             end,
             win = function()
+                github
+                    .unzip_release_file({
+                        repo = repo,
+                        asset_file = coalesce(
+                            when(platform.is.win_x64, _.format "lua-language-server-%s-win32-x64.zip"),
+                            when(platform.is.win_x86, _.format "lua-language-server-%s-win32-ia32.zip")
+                        ),
+                    })
+                    .with_receipt()
                 ctx:link_bin(
                     "lua-language-server",
                     path.concat {

--- a/lua/mason-registry/lua-language-server/init.lua
+++ b/lua/mason-registry/lua-language-server/init.lua
@@ -11,20 +11,20 @@ return Pkg.new {
     desc = [[Lua Language Server]],
     languages = { Pkg.Lang.Lua },
     categories = { Pkg.Cat.LSP },
-    homepage = "https://github.com/sumneko/lua-language-server",
+    homepage = "https://github.com/LuaLS/lua-language-server",
     ---@async
     ---@param ctx InstallContext
     install = function(ctx)
         github
             .unzip_release_file({
-                repo = "sumneko/vscode-lua",
+                repo = "LuaLS/lua-language-server",
                 asset_file = coalesce(
-                    when(platform.is.mac_x64, _.format "vscode-lua-%s-darwin-x64.vsix"),
-                    when(platform.is.mac_arm64, _.format "vscode-lua-%s-darwin-arm64.vsix"),
-                    when(platform.is.linux_x64_gnu, _.format "vscode-lua-%s-linux-x64.vsix"),
-                    when(platform.is.linux_arm64_gnu, _.format "vscode-lua-%s-linux-arm64.vsix"),
-                    when(platform.is.win_x64, _.format "vscode-lua-%s-win32-x64.vsix"),
-                    when(platform.is.win_x86, _.format "vscode-lua-%s-win32-ia32.vsix")
+                    when(platform.is.mac_x64, _.format "lua-language-server-%s-darwin-x64.tar.gz"),
+                    when(platform.is.mac_arm64, _.format "lua-language-server-%s-darwin-arm64.tar.gz"),
+                    when(platform.is.linux_x64_gnu, _.format "lua-language-server-%s-linux-x64.tar.gz"),
+                    when(platform.is.linux_arm64_gnu, _.format "lua-language-server-%s-linux-arm64.tar.gz"),
+                    when(platform.is.win_x64, _.format "lua-language-server-%s-win32-x64.zip"),
+                    when(platform.is.win_x86, _.format "lua-language-server-%s-win32-ia32.zip")
                 ),
             })
             .with_receipt()
@@ -36,8 +36,6 @@ return Pkg.new {
                     ctx:write_exec_wrapper(
                         "lua-language-server",
                         path.concat {
-                            "extension",
-                            "server",
                             "bin",
                             "lua-language-server",
                         }
@@ -48,8 +46,6 @@ return Pkg.new {
                 ctx:link_bin(
                     "lua-language-server",
                     path.concat {
-                        "extension",
-                        "server",
                         "bin",
                         "lua-language-server.exe",
                     }


### PR DESCRIPTION
Mostly just a little cleanup.
Nothing is currently broken with mason (as of right now at least)


- Stop downloading extra files which are meant for the server's VSCode extension
- Use the new organization URL :)

Tested on my Window11 machine with Neovim `0.8.3`