### PR TITLE
refactor: load mason-registry.sources directly

### DIFF
--- a/lua/mason-registry/init.lua
+++ b/lua/mason-registry/init.lua
@@ -17,8 +17,6 @@ local sources = require "mason-registry.sources"
 local M = setmetatable({}, { __index = EventEmitter })
 EventEmitter.init(M)
 
-M.set_registries = sources.set_registries
-
 local scan_install_root
 
 do

--- a/lua/mason/init.lua
+++ b/lua/mason/init.lua
@@ -27,7 +27,7 @@ function M.setup(config)
 
     require "mason.api.command"
     setup_autocmds()
-    require("mason-registry").set_registries(settings.current.registries)
+    require("mason-registry.sources").set_registries(settings.current.registries)
 end
 
 return M

--- a/scripts/lua/mason-scripts/mason/generate.lua
+++ b/scripts/lua/mason-scripts/mason/generate.lua
@@ -9,7 +9,7 @@ local MASON_REGISTRY_DIR = path.concat { vim.loop.cwd(), "lua", "mason-registry"
 ---@async
 local function create_language_map()
     local registry = require "mason-registry"
-    require("mason-registry").set_registries {
+    require("mason-registry.sources").set_registries {
         "lua:mason-registry.index",
     }
     print "Creating language map…"

--- a/scripts/lua/mason-scripts/mason/generate_package_index.lua
+++ b/scripts/lua/mason-scripts/mason/generate_package_index.lua
@@ -6,7 +6,7 @@ local markdown = require "mason-scripts.markdown"
 ---@async
 local function create_markdown_index()
     local registry = require "mason-registry"
-    require("mason-registry").set_registries {
+    require("mason-registry.sources").set_registries {
         "lua:mason-registry.index",
     }
     print "Creating markdown index…"


### PR DESCRIPTION
This further reduces the amount of modules loaded during setup.
