### PR TITLE
feat(registry): ensure pyproject.toml support for pydocstyle

### DIFF
--- a/lua/mason-registry/index/pydocstyle/init.lua
+++ b/lua/mason-registry/index/pydocstyle/init.lua
@@ -7,5 +7,5 @@ return Pkg.new {
     homepage = "https://www.pydocstyle.org/",
     languages = { Pkg.Lang.Python },
     categories = { Pkg.Cat.Linter },
-    install = pip3.packages { "pydocstyle", bin = { "pydocstyle" } },
+    install = pip3.packages { "pydocstyle[toml]", bin = { "pydocstyle" } },
 }


### PR DESCRIPTION
Pydocstyle only supports `pyproject.toml` if the `toml` package is installed.