### PR TITLE
feat: set $MASON and $MANPATH

### DIFF
--- a/lua/mason/init.lua
+++ b/lua/mason/init.lua
@@ -18,11 +18,16 @@ function M.setup(config)
     if config then
         settings.set(config)
     end
+    vim.env.MASON = settings.current.install_root_dir
 
     if settings.current.PATH == "prepend" then
         vim.env.PATH = path.bin_prefix() .. platform.path_sep .. vim.env.PATH
     elseif settings.current.PATH == "append" then
         vim.env.PATH = vim.env.PATH .. platform.path_sep .. path.bin_prefix()
+    end
+
+    if platform.is.unix then
+        vim.env.MANPATH = path.share_prefix "man" .. ":" .. (vim.env.MANPATH or "")
     end
 
     require "mason.api.command"

--- a/tests/mason/setup_spec.lua
+++ b/tests/mason/setup_spec.lua
@@ -1,10 +1,14 @@
 local match = require "luassert.match"
 local mason = require "mason"
 local path = require "mason-core.path"
+local settings = require "mason.settings"
 
 describe("mason setup", function()
     before_each(function()
+        vim.env.MASON = nil
+        vim.env.MANPATH = nil
         vim.env.PATH = "/usr/local/bin:/usr/bin"
+        settings.set(settings._DEFAULT_SETTINGS)
     end)
 
     it("should enhance the PATH environment", function()
@@ -26,6 +30,24 @@ describe("mason setup", function()
         local PATH = vim.env.PATH
         mason.setup { PATH = "skip" }
         assert.equals(PATH, vim.env.PATH)
+    end)
+
+    it("should set MASON env", function()
+        assert.is_nil(vim.env.MASON)
+        mason.setup()
+        assert.equals(vim.fn.expand "~/.local/share/nvim/mason", vim.env.MASON)
+    end)
+
+    it("should set MANPATH env", function()
+        assert.is_nil(vim.env.MANPATH)
+        mason.setup()
+        assert.equals(vim.fn.expand "~/.local/share/nvim/mason/share/man:", vim.env.MANPATH)
+    end)
+
+    it("should prepend MANPATH env", function()
+        vim.env.MANPATH = "/usr/share/man"
+        mason.setup()
+        assert.equals(vim.fn.expand "~/.local/share/nvim/mason/share/man:/usr/share/man", vim.env.MANPATH)
     end)
 
     it("should set up user commands", function()


### PR DESCRIPTION
Enables leveraging env var to expand Mason paths, e.g. `vim.fn.expand("$MASON/share/jdtls/org.eclipse.equinox.launcher.jar")`.