### PR TITLE
refactor: don't set MANPATH explicitly

### DIFF
--- a/lua/mason/init.lua
+++ b/lua/mason/init.lua
@@ -26,10 +26,6 @@ function M.setup(config)
         vim.env.PATH = vim.env.PATH .. platform.path_sep .. path.bin_prefix()
     end
 
-    if platform.is.unix then
-        vim.env.MANPATH = path.share_prefix "man" .. ":" .. (vim.env.MANPATH or "")
-    end
-
     require "mason.api.command"
     setup_autocmds()
     require("mason-registry.sources").set_registries(settings.current.registries)

--- a/tests/mason/setup_spec.lua
+++ b/tests/mason/setup_spec.lua
@@ -6,7 +6,6 @@ local settings = require "mason.settings"
 describe("mason setup", function()
     before_each(function()
         vim.env.MASON = nil
-        vim.env.MANPATH = nil
         vim.env.PATH = "/usr/local/bin:/usr/bin"
         settings.set(settings._DEFAULT_SETTINGS)
     end)
@@ -36,18 +35,6 @@ describe("mason setup", function()
         assert.is_nil(vim.env.MASON)
         mason.setup()
         assert.equals(vim.fn.expand "~/.local/share/nvim/mason", vim.env.MASON)
-    end)
-
-    it("should set MANPATH env", function()
-        assert.is_nil(vim.env.MANPATH)
-        mason.setup()
-        assert.equals(vim.fn.expand "~/.local/share/nvim/mason/share/man:", vim.env.MANPATH)
-    end)
-
-    it("should prepend MANPATH env", function()
-        vim.env.MANPATH = "/usr/share/man"
-        mason.setup()
-        assert.equals(vim.fn.expand "~/.local/share/nvim/mason/share/man:/usr/share/man", vim.env.MANPATH)
     end)
 
     it("should set up user commands", function()


### PR DESCRIPTION
After reading through `manpath(1)` a bit more thoroughly, this should not be needed due to `PATH` already being set.
