### PR TITLE
feat(registry): add snakefmt

### DIFF
--- a/lua/mason-registry/index/init.lua
+++ b/lua/mason-registry/index/init.lua
@@ -226,6 +226,7 @@ return {
   ["shopify-theme-check"] = "mason-registry.index.shopify-theme-check",
   ["slint-lsp"] = "mason-registry.index.slint-lsp",
   ["smithy-language-server"] = "mason-registry.index.smithy-language-server",
+  snakefmt = "mason-registry.index.snakefmt",
   solang = "mason-registry.index.solang",
   solargraph = "mason-registry.index.solargraph",
   solhint = "mason-registry.index.solhint",

--- a/lua/mason-registry/index/snakefmt/init.lua
+++ b/lua/mason-registry/index/snakefmt/init.lua
@@ -1,0 +1,11 @@
+local Pkg = require "mason-core.package"
+local pip3 = require "mason-core.managers.pip3"
+
+return Pkg.new {
+    name = "snakefmt",
+    desc = "The uncompromising Snakemake code formatter",
+    homepage = "https://github.com/snakemake/snakefmt",
+    languages = { Pkg.Lang.Snakemake },
+    categories = { Pkg.Cat.Formatter },
+    install = pip3.packages { "snakefmt", bin = { "snakefmt" } },
+}

--- a/lua/mason/mappings/language.lua
+++ b/lua/mason/mappings/language.lua
@@ -116,6 +116,7 @@ return {
   shell = { "shfmt" },
   slint = { "slint-lsp" },
   smithy = { "smithy-language-server" },
+  snakemake = { "snakefmt" },
   solidity = { "solang", "solhint", "solidity", "solidity-ls" },
   sphinx = { "esbonio" },
   sql = { "sql-formatter", "sqlfluff", "sqlls", "sqls" },


### PR DESCRIPTION
This adds [`snakefmt`](https://github.com/snakemake/snakefmt), a formatter for the workflow management system [`Snakemake`](https://github.com/snakemake/snakemake).

I copied this from the `black` init.lua, I'm not sure if the duplicated snakefmt in this line is needed:
```lua
    pip3.packages { "snakefmt", bin = { "snakefmt" } },
```