### PR TITLE
feat(registry): add cql-language-server

### DIFF
--- a/lua/mason-registry/index/cql-language-server/init.lua
+++ b/lua/mason-registry/index/cql-language-server/init.lua
@@ -1,0 +1,47 @@
+local Pkg = require "mason-core.package"
+local std = require "mason-core.managers.std"
+local github = require "mason-core.managers.github"
+local git = require "mason-core.managers.git"
+local Optional = require "mason-core.optional"
+local path = require "mason-core.path"
+local _ = require "mason-core.functional"
+
+return Pkg.new {
+    name = "cql-language-server",
+    desc = [[A language server for Clinical Quality Language (CQL)]],
+    homepage = "https://github.com/cqframework/cql-language-server",
+    languages = { Pkg.Lang.cqlang },
+    categories = { Pkg.Cat.LSP },
+    --@async
+    --@param ctx InstallContext
+    install = function(ctx)
+        std.ensure_executable("mvn", {
+            help_url = "https://maven.apache.org/download.cgi",
+        })
+
+        local source = github.tag { repo = "cqframework/cql-language-server" }
+        source.with_receipt()
+        git.clone {
+            "https://github.com/cqframework/cql-language-server",
+            version = Optional.of(source.tag),
+        }
+
+        local version = _.gsub("^v", "", source.tag)
+
+        ctx.spawn.mvn { "package", "-DskipTests" }
+
+        ctx:link_bin(
+            "cql-language-server",
+            ctx:write_shell_exec_wrapper(
+                "cql-language-server",
+                ("java -jar %q"):format(path.concat {
+                    ctx.package:get_install_path(),
+                    "ls",
+                    "service",
+                    "target",
+                    ("cql-ls-service-%s.jar"):format(version),
+                })
+            )
+        )
+    end,
+}

--- a/lua/mason-registry/index/init.lua
+++ b/lua/mason-registry/index/init.lua
@@ -46,6 +46,7 @@ return {
   commitlint = "mason-registry.index.commitlint",
   cpplint = "mason-registry.index.cpplint",
   cpptools = "mason-registry.index.cpptools",
+  ["cql-language-server"] = "mason-registry.index.cql-language-server",
   crystalline = "mason-registry.index.crystalline",
   ["csharp-language-server"] = "mason-registry.index.csharp-language-server",
   csharpier = "mason-registry.index.csharpier",

--- a/lua/mason/mappings/language.lua
+++ b/lua/mason/mappings/language.lua
@@ -26,6 +26,7 @@ return {
   clojurescript = { "clojure-lsp", "joker" },
   cmake = { "cmake-language-server", "cmakelang", "gersemi", "neocmakelsp" },
   codeql = { "codeql" },
+  cqlang = { "cql-language-server" },
   crystal = { "crystalline" },
   csh = { "beautysh" },
   css = { "css-lsp", "cssmodules-language-server", "prettier", "prettierd", "tailwindcss-language-server", "unocss-language-server" },


### PR DESCRIPTION
Thanks for the great plugin! Mason is super useful. I wanted to add support for building the JAR file for the [cql-language-server](https://github.com/cqframework/cql-language-server), which is useful for editing Clinical Quality Language (CQL) files.

Unfortunately, they don't publish the packaged JAR along with a GitHub release, so the  Mason package uses [maven](https://maven.apache.org/download.cgi) to build the JAR from source as the README in cql-language-server suggests (I used #907 as inspiration for some of the maven build steps in the install callback).

This is my first contribution to Mason, so I wanted to ask:

* Does the file type set for `Pkg.Lang.*` need to match the ftdetect matched by neovim? The official filetype is `cqlang`, but `CQL` is shorthand that CQL developers are more likely to recognize
* Do I need to provide proof of the LSP setup working with the downloaded JAR/linked executable? I am currently working on a companion contribution to nvim-lspconfig, so I could hold off on this until the lsp configuration is accepted. I'll attach a gif of proof that the downloaded mason executable works regardless:

![out](https://user-images.githubusercontent.com/16297930/222519948-758c99b1-1b5e-4ca3-a58a-23ead67fcdf1.gif)
