### PR TITLE
refactor: only schedule in a.scheduler() when in fast event

### DIFF
--- a/lua/mason-core/async/init.lua
+++ b/lua/mason-core/async/init.lua
@@ -150,7 +150,9 @@ exports.sleep = function(ms)
 end
 
 exports.scheduler = function()
-    await(vim.schedule)
+    if vim.in_fast_event() then
+        await(vim.schedule)
+    end
 end
 
 ---@async

--- a/lua/mason-core/functional/init.lua
+++ b/lua/mason-core/functional/init.lua
@@ -153,4 +153,25 @@ _.lazy_when = function(condition, value)
     return condition and value() or nil
 end
 
+---@param fn fun()
+_.scheduler = function(fn)
+    if vim.in_fast_event() then
+        vim.schedule(fn)
+    else
+        fn()
+    end
+end
+
+---@generic T : fun(...)
+---@param fn T
+---@return T
+_.scheduler_wrap = function(fn)
+    return function(...)
+        local args = _.table_pack(...)
+        _.scheduler(function()
+            fn(unpack(args, 1, args.n + 1))
+        end)
+    end
+end
+
 return _

--- a/lua/mason-core/installer/linker.lua
+++ b/lua/mason-core/installer/linker.lua
@@ -63,10 +63,7 @@ local function link(context, link_context, link_fn)
 
             do
                 -- 1. Ensure destination directory exists
-                if vim.in_fast_event() then
-                    a.scheduler()
-                end
-
+                a.scheduler()
                 local dir = vim.fn.fnamemodify(dest_abs_path, ":h")
                 if not fs.async.dir_exists(dir) then
                     try(Result.pcall(fs.async.mkdirp, dir))

--- a/lua/mason-core/installer/managers/pypi.lua
+++ b/lua/mason-core/installer/managers/pypi.lua
@@ -55,9 +55,7 @@ function M.init(opts)
         log.fmt_debug("pypi: init", opts)
         local ctx = installer.context()
 
-        if vim.in_fast_event() then
-            a.scheduler()
-        end
+        a.scheduler()
 
         local executables = platform.is.win
                 and _.list_not_nil(

--- a/lua/mason-core/installer/registry/init.lua
+++ b/lua/mason-core/installer/registry/init.lua
@@ -141,10 +141,8 @@ end
 function M.compile(spec, opts)
     log.debug("Compiling installer.", spec.name, opts)
     return Result.try(function(try)
-        if vim.in_fast_event() then
-            -- Parsers run synchronously and may access API functions, so we schedule before-hand.
-            a.scheduler()
-        end
+        -- Parsers run synchronously and may access API functions, so we schedule before-hand.
+        a.scheduler()
 
         local map_parse_err = _.cond {
             {

--- a/lua/mason-core/installer/registry/link.lua
+++ b/lua/mason-core/installer/registry/link.lua
@@ -214,9 +214,7 @@ local function expand_file_spec(ctx, purl, source, file_spec_table)
                     return Result.failure(("Cannot link file %q to dir %q."):format(source_path, dest))
                 end
 
-                if vim.in_fast_event() then
-                    a.scheduler()
-                end
+                a.scheduler()
 
                 local glob = path.concat { cwd, source_path } .. "**/*"
                 log.fmt_trace("Symlink glob for %s: %s", ctx.package, glob)

--- a/lua/mason-core/installer/registry/providers/github.lua
+++ b/lua/mason-core/installer/registry/providers/github.lua
@@ -113,9 +113,7 @@ local release = {
             end))
 
             for __, download in ipairs(source.downloads) do
-                if vim.in_fast_event() then
-                    a.scheduler()
-                end
+                a.scheduler()
                 local out_dir = vim.fn.fnamemodify(download.out_file, ":h")
                 local out_file = vim.fn.fnamemodify(download.out_file, ":t")
                 if out_dir ~= "." then

--- a/lua/mason-core/managers/cargo/init.lua
+++ b/lua/mason-core/managers/cargo/init.lua
@@ -144,9 +144,7 @@ end
 ---@param receipt InstallReceipt<InstallReceiptPackageSource>
 ---@param install_dir string
 function M.check_outdated_primary_package(receipt, install_dir)
-    if vim.in_fast_event() then
-        a.scheduler()
-    end
+    a.scheduler()
     local crate_name = vim.fn.fnamemodify(receipt.primary_source.package, ":t")
     return get_installed_crates(install_dir)
         :ok()
@@ -189,9 +187,7 @@ end
 ---@param receipt InstallReceipt<InstallReceiptPackageSource>
 ---@param install_dir string
 function M.get_installed_primary_package_version(receipt, install_dir)
-    if vim.in_fast_event() then
-        a.scheduler()
-    end
+    a.scheduler()
     local crate_name = vim.fn.fnamemodify(receipt.primary_source.package, ":t")
     return get_installed_crates(install_dir)
         :ok()

--- a/lua/mason-core/managers/go/init.lua
+++ b/lua/mason-core/managers/go/init.lua
@@ -114,9 +114,7 @@ end
 ---@param receipt InstallReceipt<InstallReceiptPackageSource>
 ---@param install_dir string
 function M.get_installed_primary_package_version(receipt, install_dir)
-    if vim.in_fast_event() then
-        a.scheduler()
-    end
+    a.scheduler()
     local normalized_pkg_name = trim_wildcard_suffix(receipt.primary_source.package)
     -- trims e.g. golang.org/x/tools/gopls to gopls
     local executable = vim.fn.fnamemodify(normalized_pkg_name, ":t")

--- a/lua/mason-core/managers/pip3/init.lua
+++ b/lua/mason-core/managers/pip3/init.lua
@@ -46,9 +46,7 @@ function M.install(packages)
         pkgs[1] = ("%s==%s"):format(pkgs[1], version)
     end)
 
-    if vim.in_fast_event() then
-        a.scheduler()
-    end
+    a.scheduler()
 
     local executables = platform.is.win
             and _.list_not_nil(vim.g.python3_host_prog and vim.fn.expand(vim.g.python3_host_prog), "python", "python3")

--- a/lua/mason-core/managers/powershell/init.lua
+++ b/lua/mason-core/managers/powershell/init.lua
@@ -12,9 +12,7 @@ local PWSHOPT = {
 }
 
 local powershell = _.lazy(function()
-    if vim.in_fast_event() then
-        a.scheduler()
-    end
+    a.scheduler()
     if vim.fn.executable "pwsh" == 1 then
         return "pwsh"
     else

--- a/lua/mason-core/managers/std/init.lua
+++ b/lua/mason-core/managers/std/init.lua
@@ -21,9 +21,7 @@ end
 function M.ensure_executable(executable, opts)
     local ctx = installer.context()
     opts = opts or {}
-    if vim.in_fast_event() then
-        a.scheduler()
-    end
+    a.scheduler()
     if vim.fn.executable(executable) ~= 1 then
         ctx.stdio_sink.stderr(("%s was not found in path.\n"):format(executable))
         if opts.help_url then
@@ -190,9 +188,7 @@ end
 ---@params opts
 function M.select(items, opts)
     assert(not platform.is_headless, "Tried to prompt for user input while in headless mode.")
-    if vim.in_fast_event() then
-        a.scheduler()
-    end
+    a.scheduler()
     local async_select = a.promisify(vim.ui.select)
     return async_select(items, opts)
 end

--- a/lua/mason-core/spawn.lua
+++ b/lua/mason-core/spawn.lua
@@ -34,9 +34,7 @@ local function Failure(err, cmd)
 end
 
 local is_executable = _.memoize(function(cmd)
-    if vim.in_fast_event() then
-        a.scheduler()
-    end
+    a.scheduler()
     return vim.fn.executable(cmd) == 1
 end, _.identity)
 

--- a/lua/mason-registry/index/ltex-ls/init.lua
+++ b/lua/mason-registry/index/ltex-ls/init.lua
@@ -61,9 +61,7 @@ return Pkg.new {
     ---@async
     ---@param ctx InstallContext
     install = function(ctx)
-        if vim.in_fast_event() then
-            a.scheduler()
-        end
+        a.scheduler()
         if vim.fn.executable "java" == 1 then
             download_platform_independent()
         else

--- a/lua/mason-registry/init.lua
+++ b/lua/mason-registry/init.lua
@@ -176,15 +176,11 @@ function M.refresh(cb)
 
     ---@async
     local function refresh()
-        if vim.in_fast_event() then
-            a.scheduler()
-        end
+        a.scheduler()
         local is_outdated = get_store_age(os.time()) > REGISTRY_STORE_TTL
         if is_outdated or not sources.is_installed() then
             if a.wait(M.update) then
-                if vim.in_fast_event() then
-                    a.scheduler()
-                end
+                a.scheduler()
                 update_store_timestamp(os.time())
             end
         end

--- a/lua/mason/api/command.lua
+++ b/lua/mason/api/command.lua
@@ -66,8 +66,8 @@ local function join_handles(handles)
         end, handles)
 
         if _.length(failed_packages) > 0 then
-            a.scheduler() -- wait for scheduler for logs to finalize
-            a.scheduler() -- logs have been written
+            a.wait(vim.schedule) -- wait for scheduler for logs to finalize
+            a.wait(vim.schedule) -- logs have been written
             vim.api.nvim_err_writeln ""
             vim.api.nvim_err_writeln(
                 ("The following packages failed to install: %s"):format(_.join(", ", failed_packages))

--- a/lua/mason/health/init.lua
+++ b/lua/mason/health/init.lua
@@ -306,9 +306,7 @@ function M.check()
             :map(
                 ---@param rate_limit GitHubRateLimitResponse
                 function(rate_limit)
-                    if vim.in_fast_event() then
-                        a.scheduler()
-                    end
+                    a.scheduler()
                     local remaining = rate_limit.resources.core.remaining
                     local used = rate_limit.resources.core.used
                     local limit = rate_limit.resources.core.limit
@@ -327,9 +325,7 @@ function M.check()
                 end
             )
             :on_failure(function()
-                if vim.in_fast_event() then
-                    a.scheduler()
-                end
+                a.scheduler()
                 health.report_warn "Failed to check GitHub API rate limit status."
             end)
     end)

--- a/tests/mason-core/EventEmitter_spec.lua
+++ b/tests/mason-core/EventEmitter_spec.lua
@@ -49,7 +49,7 @@ describe("EventEmitter", function()
             local emitter = EventEmitter.init(setmetatable({}, { __index = EventEmitter }))
             emitter:on("event", mockx.throws "My error.")
             emitter:emit "event"
-            a.scheduler()
+            a.wait(vim.schedule)
             assert.spy(vim.api.nvim_err_writeln).was_called(1)
             assert.spy(vim.api.nvim_err_writeln).was_called_with "My error."
         end)

--- a/tests/mason-core/managers/powershell_spec.lua
+++ b/tests/mason-core/managers/powershell_spec.lua
@@ -32,7 +32,6 @@ describe("powershell manager", function()
             vim.fn.executable.on_call_with("pwsh").returns(0)
 
             local powershell = powershell()
-            a.scheduler()
             powershell.command "echo 'Is this bash?'"
 
             assert.spy(spawn.pwsh).was_called(0)

--- a/tests/mason-core/terminator_spec.lua
+++ b/tests/mason-core/terminator_spec.lua
@@ -27,7 +27,7 @@ describe("terminator", function()
             local dummy2_handle = dummy2:install()
             terminator.terminate(5000)
 
-            a.scheduler()
+            a.wait(vim.schedule)
             assert.spy(InstallHandle.terminate).was_called(2)
             assert.spy(InstallHandle.terminate).was_called_with(match.is_ref(dummy_handle))
             assert.spy(InstallHandle.terminate).was_called_with(match.is_ref(dummy2_handle))
@@ -67,7 +67,7 @@ describe("terminator", function()
                 },
             }, true, {})
 
-            a.scheduler()
+            a.wait(vim.schedule)
 
             assert.spy(vim.api.nvim_err_writeln).was_called(1)
             assert.spy(vim.api.nvim_err_writeln).was_called_with(_.dedent [[

--- a/tests/mason-core/ui_spec.lua
+++ b/tests/mason-core/ui_spec.lua
@@ -186,7 +186,7 @@ describe("integration test", function()
             window.open()
 
             -- Initial window and buffer creation + initial render
-            a.scheduler()
+            a.wait(vim.schedule)
 
             assert.spy(win_set_option).was_called(9)
             assert.spy(win_set_option).was_called_with(match.is_number(), "number", false)
@@ -245,7 +245,7 @@ describe("integration test", function()
             end)
 
             assert.spy(set_lines).was_called(1)
-            a.scheduler()
+            a.wait(vim.schedule)
             assert.spy(set_lines).was_called(2)
 
             assert
@@ -288,12 +288,12 @@ describe("integration test", function()
             local mutate_state = window.state { show_extra_lines = false }
             window.init {}
             window.open()
-            a.scheduler()
+            a.wait(vim.schedule)
             window.set_cursor { 5, 3 } -- move cursor to sticky line
             mutate_state(function(state)
                 state.show_extra_lines = true
             end)
-            a.scheduler()
+            a.wait(vim.schedule)
             local cursor = window.get_cursor()
             assert.same({ 8, 3 }, cursor)
         end)
@@ -311,7 +311,7 @@ describe("integration test", function()
             window.state {}
             window.init { border = "rounded" }
             window.open()
-            a.scheduler()
+            a.wait(vim.schedule)
 
             assert.spy(nvim_open_win).was_called(1)
             assert.spy(nvim_open_win).was_called_with(

--- a/tests/mason/api/command_spec.lua
+++ b/tests/mason/api/command_spec.lua
@@ -13,7 +13,7 @@ describe(":Mason", function()
         "should open the UI window",
         async_test(function()
             api.Mason()
-            a.scheduler()
+            a.wait(vim.schedule)
             local win = vim.api.nvim_get_current_win()
             local buf = vim.api.nvim_win_get_buf(win)
             assert.equals("mason", vim.api.nvim_buf_get_option(buf, "filetype"))
@@ -103,7 +103,7 @@ describe(":MasonUpdate", function()
             assert.spy(vim.notify).was_called_with("Updating registries…", vim.log.levels.INFO, {
                 title = "mason.nvim",
             })
-            a.scheduler()
+            a.wait(vim.schedule)
             assert.spy(vim.notify).was_called_with("Successfully updated 1 registry.", vim.log.levels.INFO, {
                 title = "mason.nvim",
             })
@@ -122,7 +122,7 @@ describe(":MasonUpdate", function()
             assert.spy(vim.notify).was_called_with("Updating registries…", vim.log.levels.INFO, {
                 title = "mason.nvim",
             })
-            a.scheduler()
+            a.wait(vim.schedule)
             assert.spy(vim.notify).was_called_with("Failed to update registries: Some error.", vim.log.levels.ERROR, {
                 title = "mason.nvim",
             })


### PR DESCRIPTION
Explicitly schedule via `a.wait(vim.schedule)` instead.
