### PR TITLE
chore(health): relax unzip requirement

### DIFF
--- a/lua/mason/health.lua
+++ b/lua/mason/health.lua
@@ -155,6 +155,7 @@ function M.check()
             name = "unzip",
             cmd = "unzip",
             args = { "-v" },
+            relaxed = true,
         },
         check {
             cmd = "go",


### PR DESCRIPTION
No longer a hard requirement due to vendoring lua zzlib.
