### PR TITLE
refactor(expr): remove redundant core filters and always stringify reduced value

### DIFF
--- a/lua/mason-core/functional/init.lua
+++ b/lua/mason-core/functional/init.lua
@@ -70,6 +70,7 @@ _.index_by = list.index_by
 ---@module "mason-core.functional.relation"
 local relation = lazy_require "mason-core.functional.relation"
 _.equals = relation.equals
+_.not_equals = relation.not_equals
 _.prop_eq = relation.prop_eq
 _.prop_satisfies = relation.prop_satisfies
 _.path_satisfies = relation.path_satisfies

--- a/lua/mason-core/functional/relation.lua
+++ b/lua/mason-core/functional/relation.lua
@@ -6,6 +6,10 @@ _.equals = fun.curryN(function(expected, value)
     return value == expected
 end, 2)
 
+_.not_equals = fun.curryN(function(expected, value)
+    return value ~= expected
+end, 2)
+
 _.prop_eq = fun.curryN(function(property, value, tbl)
     return tbl[property] == value
 end, 3)

--- a/tests/mason-core/functional/relation_spec.lua
+++ b/tests/mason-core/functional/relation_spec.lua
@@ -14,6 +14,19 @@ describe("functional: relation", function()
         assert.is_false(is_42(32))
     end)
 
+    it("should check non-equality", function()
+        local tbl = {}
+        local is_not_tbl = _.not_equals(tbl)
+        local is_not_a = _.not_equals "a"
+        local is_not_42 = _.not_equals(42)
+
+        assert.is_false(is_not_tbl(tbl))
+        assert.is_false(is_not_a "a")
+        assert.is_false(is_not_42(42))
+        assert.is_true(is_not_a "b")
+        assert.is_true(is_not_42(32))
+    end)
+
     it("should check property equality", function()
         local fn_key = function() end
         local tbl = { a = "a", b = "b", number = 42, [fn_key] = "fun" }

--- a/tests/mason-core/installer/registry/expr_spec.lua
+++ b/tests/mason-core/installer/registry/expr_spec.lua
@@ -1,4 +1,5 @@
 local Result = require "mason-core.result"
+local _ = require "mason-core.functional"
 local expr = require "mason-core.installer.registry.expr"
 local match = require "luassert.match"
 
@@ -27,6 +28,7 @@ describe("registry expressions", function()
             Result.success "Hello, JOHNDOE JR.!",
             expr.interpolate("Hello, {{greeting.firstname .. greeting.lastname .. tostring(tbl) | to_upper}}!", {
                 greeting = { firstname = "John", lastname = "Doe" },
+                tostring = tostring,
                 tbl = setmetatable({}, {
                     __tostring = function()
                         return " Jr."
@@ -48,6 +50,7 @@ describe("registry expressions", function()
             Result.success "Hello, MR. John!",
             expr.interpolate("Hello, {{prefix|to_upper}} {{  name | trim   }}!", {
                 prefix = "Mr.",
+                trim = _.trim,
                 name = " John   ",
             })
         )
@@ -55,6 +58,8 @@ describe("registry expressions", function()
         assert.same(
             Result.success "Hello, Sir MR. John!",
             expr.interpolate("Hello, {{prefix|to_upper | format 'Sir %s'}} {{  name | trim   }}!", {
+                format = _.format,
+                trim = _.trim,
                 prefix = "Mr.",
                 name = " John   ",
             })
@@ -83,6 +88,102 @@ describe("registry expressions", function()
             match.matches [[^.*Failed to parse expression: "wh%-!uut"]](
                 expr.interpolate("Hello, {{ value | wh-!uut }}", { value = "value" }):err_or_nil()
             )
+        )
+    end)
+end)
+
+describe("expr filters :: equals/not_equals", function()
+    it("should equals", function()
+        assert.same(
+            Result.success "true",
+            expr.interpolate("{{equals('Hello, world!', value)}}", {
+                value = "Hello, world!",
+            })
+        )
+
+        assert.same(
+            Result.success "true",
+            expr.interpolate("{{ value | equals('Hello, world!') }}", {
+                value = "Hello, world!",
+            })
+        )
+
+        assert.same(
+            Result.success "false",
+            expr.interpolate("{{ value | equals('Hello, John!') }}", {
+                value = "Hello, world!",
+            })
+        )
+    end)
+
+    it("should not equals", function()
+        assert.same(
+            Result.success "true",
+            expr.interpolate("{{not_equals('Hello, John!', value)}}", {
+                value = "Hello, world!",
+            })
+        )
+
+        assert.same(
+            Result.success "true",
+            expr.interpolate("{{ value | not_equals('Hello, John!') }}", {
+                value = "Hello, world!",
+            })
+        )
+
+        assert.same(
+            Result.success "false",
+            expr.interpolate("{{ value | not_equals('Hello, world!') }}", {
+                value = "Hello, world!",
+            })
+        )
+    end)
+end)
+
+describe("expr filters :: take_if{_not}", function()
+    it("should take if value matches", function()
+        assert.same(
+            Result.success "Hello, world!",
+            expr.interpolate("Hello, {{ take_if(equals('world!'), value) }}", {
+                value = "world!",
+            })
+        )
+
+        assert.same(
+            Result.success "Hello, world!",
+            expr.interpolate("Hello, {{ value | take_if(equals('world!')) }}", {
+                value = "world!",
+            })
+        )
+
+        assert.same(
+            Result.success "",
+            expr.interpolate("{{ take_if(equals('Hello John!'), greeting) }}", {
+                greeting = "Hello World!",
+            })
+        )
+    end)
+
+    it("should not take if value matches", function()
+        assert.same(
+            Result.success "Hello, world!",
+            expr.interpolate("Hello, {{ take_if_not(equals('John!'), value) }}", {
+                value = "world!",
+            })
+        )
+
+        assert.same(
+            Result.success "Hello, world!",
+            expr.interpolate("Hello, {{ value | take_if_not(equals('john!')) }}", {
+                value = "world!",
+            })
+        )
+
+        assert.same(
+            Result.success "",
+            expr.interpolate("{{ take_if_not(equals('Hello World!'), greeting) }}", {
+                greeting = "Hello World!",
+            })
         )
     end)
 end)


### PR DESCRIPTION
The removed filters are not used by mason-registry and are too Lua-specific in nature.
