### PR TITLE
feat(registry): add .get_all_package_specs()

### DIFF
--- a/doc/mason.txt
+++ b/doc/mason.txt
@@ -492,11 +492,19 @@ get_all_packages()
 
                                       *mason-registry.get_all_package_names()*
 get_all_package_names()
-    Returns all package names. This is a fast function that doesn't load any
-    extra modules.
+    Returns all package names. This is a faster function than
+    |mason-registry.get_all_packages()| because it loads fewer modules.
 
     Returns:
         string[]
+
+                                      *mason-registry.get_all_package_specs()*
+get_all_package_specs()
+    Returns all package specifications. This is a faster function than
+    |mason-registry.get_all_packages()| because it loads fewer modules.
+
+    Returns:
+        (PackageSpec | RegistryPackageSpec)[]
 
                                                      *mason-registry.update()*
 update({callback})

--- a/lua/mason-registry/init.lua
+++ b/lua/mason-registry/init.lua
@@ -10,6 +10,7 @@ local sources = require "mason-registry.sources"
 ---@field id string
 ---@field get_package fun(self: RegistrySource, pkg_name: string): Package?
 ---@field get_all_package_names fun(self: RegistrySource): string[]
+---@field get_all_package_specs fun(self: RegistrySource): PackageSpec[] | RegistryPackageSpec[]
 ---@field get_display_name fun(self: RegistrySource): string
 ---@field is_installed fun(self: RegistrySource): boolean
 ---@field get_installer fun(self: RegistrySource): Optional # Optional<async fun (): Result>
@@ -117,6 +118,15 @@ end
 ---@return Package[]
 function M.get_all_packages()
     return get_packages(M.get_all_package_names())
+end
+
+---@return (RegistryPackageSpec | PackageSpec)[]
+function M.get_all_package_specs()
+    local specs = {}
+    for source in sources.iter() do
+        vim.list_extend(specs, source:get_all_package_specs())
+    end
+    return _.uniq_by(_.prop "name", specs)
 end
 
 local STATE_FILE = path.concat {

--- a/lua/mason-registry/sources/lua.lua
+++ b/lua/mason-registry/sources/lua.lua
@@ -1,3 +1,5 @@
+local Optional = require "mason-core.optional"
+local _ = require "mason-core.functional"
 local log = require "mason-core.log"
 
 ---@class LuaRegistrySourceSpec
@@ -35,6 +37,13 @@ end
 function LuaRegistrySource:get_all_package_names()
     local index = require(self.spec.mod)
     return vim.tbl_keys(index)
+end
+
+---@return PackageSpec[]
+function LuaRegistrySource:get_all_package_specs()
+    return _.filter_map(function(name)
+        return Optional.of_nilable(self:get_package(name)):map(_.prop "spec")
+    end, self:get_all_package_names())
 end
 
 function LuaRegistrySource:is_installed()

--- a/tests/mason-registry/registry_spec.lua
+++ b/tests/mason-registry/registry_spec.lua
@@ -17,4 +17,8 @@ describe("mason-registry", function()
         assert.is_true(registry.has_package "dummy")
         assert.is_false(registry.has_package "non-existent")
     end)
+
+    it("should get all package specs", function()
+        assert.equals(3, #registry.get_all_package_specs())
+    end)
 end)


### PR DESCRIPTION
This is a faster method than .get_all_packages() due to the fact that it only loads package specifications without
instantiating mason-core.package instances. Useful for situations where one only needs to read spec data.
