### PR TITLE
refactor(linker): copy_file instead of rename on Windows

### DIFF
--- a/lua/mason-core/fs.lua
+++ b/lua/mason-core/fs.lua
@@ -86,6 +86,14 @@ local function make_module(uv)
     end
 
     ---@param path string
+    ---@param new_path string
+    ---@param flags table? { excl?: boolean, ficlone?: boolean, ficlone_force?: boolean }
+    function M.copy_file(path, new_path, flags)
+        log.debug("fs: copy_file", path, new_path, flags)
+        uv.fs_copyfile(path, new_path, flags)
+    end
+
+    ---@param path string
     ---@param contents string
     ---@param flags string? Defaults to "w".
     function M.write_file(path, contents, flags)

--- a/lua/mason-core/installer/linker.lua
+++ b/lua/mason-core/installer/linker.lua
@@ -102,9 +102,9 @@ end
 
 ---@param context InstallContext
 ---@param link_context LinkContext
-local function rename(context, link_context)
+local function copyfile(context, link_context)
     return link(context, link_context, function(new_abs_path, target_abs_path)
-        return Result.pcall(fs.async.rename, target_abs_path, new_abs_path)
+        return Result.pcall(fs.async.copy_file, target_abs_path, new_abs_path, { excl = true })
     end)
 end
 
@@ -138,8 +138,8 @@ function M.link(context)
     return Result.try(function(try)
         if platform.is.win then
             try(win_bin_wrapper(context))
-            try(rename(context, LinkContext.SHARE))
-            try(rename(context, LinkContext.OPT))
+            try(copyfile(context, LinkContext.SHARE))
+            try(copyfile(context, LinkContext.OPT))
         else
             try(symlink(context, LinkContext.BIN))
             try(symlink(context, LinkContext.SHARE))

--- a/tests/mason-core/installer/linker_spec.lua
+++ b/tests/mason-core/installer/linker_spec.lua
@@ -152,7 +152,7 @@ describe("linker", function()
         end)
     )
 
-    it("should rename share files on Windows", function()
+    it("should copy share files on Windows", function()
         platform.is.darwin = false
         platform.is.mac = false
         platform.is.linux = false
@@ -163,7 +163,7 @@ describe("linker", function()
         stub(fs.async, "mkdirp")
         stub(fs.async, "dir_exists")
         stub(fs.async, "file_exists")
-        stub(fs.async, "rename")
+        stub(fs.async, "copy_file")
 
         -- mock non-existent dest files
         fs.async.file_exists.on_call_with(path.share_prefix "share-file").returns(false)
@@ -187,13 +187,14 @@ describe("linker", function()
 
         assert.is_true(result:is_success())
 
-        assert.spy(fs.async.rename).was_called(2)
+        assert.spy(fs.async.copy_file).was_called(2)
         assert
-            .spy(fs.async.rename)
-            .was_called_with(path.concat { dummy:get_install_path(), "share-file" }, path.share_prefix "share-file")
-        assert.spy(fs.async.rename).was_called_with(
+            .spy(fs.async.copy_file)
+            .was_called_with(path.concat { dummy:get_install_path(), "share-file" }, path.share_prefix "share-file", { excl = true })
+        assert.spy(fs.async.copy_file).was_called_with(
             path.concat { dummy:get_install_path(), "nested", "path", "to", "share-file" },
-            path.share_prefix "nested/path/share-file"
+            path.share_prefix "nested/path/share-file",
+            { excl = true }
         )
 
         assert.spy(fs.async.mkdirp).was_called(2)


### PR DESCRIPTION
Renaming the file will move it from its original installation directory. While reaching into package installation
directories is unsupported and not recommended, it seems to be done pretty broadly. In order to avoid unnecessarily
breaking people's configs we copy the file instead, for now. (tip: use the stable locations inside $MASON/share
$MASON/opt $MASON/bin, if a package is missing a link please open an issue/PR).

This will be reversed back to use uv_fs_rename() in 1.x.x.
