### PR TITLE
Update PACKAGES.md to point to default registry repo

### DIFF
--- a/PACKAGES.md
+++ b/PACKAGES.md
@@ -1,1 +1,1 @@
-Moved to https://mason-registry.dev/registry/list
+Moved to https://github.com/mason-org/mason-registry


### PR DESCRIPTION
When looking at the markdown it was very confusing where the packages are coming from now. This allows pointing future contributors to the right place.

Fixes confusion in #1284