### PR TITLE
fix(registry): configure registry url independent of asset url (#1300)

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,10 @@ local DEFAULT_SETTINGS = {
         -- 2. The release version (e.g. "v0.3.0")
         -- 3. The asset name (e.g. "rust-analyzer-v0.3.0-x86_64-unknown-linux-gnu.tar.gz")
         download_url_template = "https://github.com/%s/releases/download/%s/%s",
+
+        -- The template URL to use when downloading registries.
+        -- Same placeholders as download_url_template
+        registry_url_template = "https://github.com/%s/releases/download/%s/%s",
     },
 
     pip = {

--- a/lua/mason-registry/sources/github.lua
+++ b/lua/mason-registry/sources/github.lua
@@ -123,7 +123,7 @@ function GitHubRegistrySource:install()
 
     return Result.try(function(try)
         local version = self.spec.version
-        if self:is_installed() and self:get_info().version == version then
+        if self:is_installed() and self:get_info().version == version and version ~= 'latest' then
             -- Fixed version is already installed - nothing to update
             return
         end
@@ -146,7 +146,7 @@ function GitHubRegistrySource:install()
         end
 
         local zip_file = path.concat { self.root_dir, "registry.json.zip" }
-        try(fetch(settings.current.github.download_url_template:format(self.spec.repo, version, "registry.json.zip"), {
+        try(fetch(settings.current.github.registry_url_template:format(self.spec.repo, version, "registry.json.zip"), {
             out_file = zip_file,
         }):map_err(_.always "Failed to download registry archive."))
         local zip_buffer = fs.async.read_file(zip_file)
@@ -158,7 +158,7 @@ function GitHubRegistrySource:install()
         pcall(fs.async.unlink, zip_file)
 
         local checksums = try(
-            fetch(settings.current.github.download_url_template:format(self.spec.repo, version, "checksums.txt")):map_err(
+            fetch(settings.current.github.registry_url_template:format(self.spec.repo, version, "checksums.txt")):map_err(
                 _.always "Failed to download checksums.txt."
             )
         )

--- a/lua/mason/settings.lua
+++ b/lua/mason/settings.lua
@@ -46,6 +46,7 @@ local DEFAULT_SETTINGS = {
         -- 2. The release version (e.g. "v0.3.0")
         -- 3. The asset name (e.g. "rust-analyzer-v0.3.0-x86_64-unknown-linux-gnu.tar.gz")
         download_url_template = "https://github.com/%s/releases/download/%s/%s",
+        registry_url_template = "https://github.com/%s/releases/download/%s/%s",
     },
 
     pip = {


### PR DESCRIPTION
fixes #1300 which is incorrectly marked closed.

Adds a configuration key for the registry url.
Also, will always download the registry if the registry configuration is pinned to "latest".

This allows  mason to work in a secure corporate environment where the mason registry api is not available, but a mirror of `mason-org/mason-registry` is available.

Supports this neovim/mason configuration:

```lua
require('mason').setup({
  -- use curl / wget to resolve metadata, skips version check against https://api.mason-registry.dev
  providers = { "mason.providers.client" },

  registries = { "github:mason-org/mason-registry@latest" },

  github = {
    download_url_template = 'https://proxy.corporate.com/github/%s/releases/download/%s/%s',
    registry_url_template = 'https://proxy.corporate.com/github/%s/releases/%s/download/%s',
  }
})
```

I have been running neovim with this code change applied to mason for a few days now.
Testing:

Using custom configuration:
* verified that the timestamp is getting updated in `~/.local/share/nvim/mason/registries/github/mason-org/mason-registry/info.json` after repeated runs.
* enabled debug-level logging and verified that there are no errors and that the registry download proceeds normally

Using normal configuration:
* verified that nothing is broken by this change. 