### PR TITLE
docs: remove :MasonUpdate from plugin manager lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,7 @@ your personal usage, some of these will also need to be installed. Refer to `:ch
 
 ```lua
 use {
-    "williamboman/mason.nvim",
-    run = ":MasonUpdate" -- :MasonUpdate updates registry contents
+    "williamboman/mason.nvim"
 }
 ```
 
@@ -108,15 +107,13 @@ use {
 ```lua
 {
     "williamboman/mason.nvim",
-    build = ":MasonUpdate" -- :MasonUpdate updates registry contents
 }
 ```
 
 ## [vim-plug](https://github.com/junegunn/vim-plug)
 
 ```vim
-" :MasonUpdate updates registry contents
-Plug 'williamboman/mason.nvim', { 'do': ':MasonUpdate' }
+Plug 'williamboman/mason.nvim'
 ```
 
 # Setup


### PR DESCRIPTION
This is really not necessary and is problematic because the plugin must have been setup before this command is executed.
