### PR TITLE
fix(std): use gtar if available

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,22 @@ party plugins to further integrate these. The following plugins are recommended:
 The _minimum_ recommended requirements are:
 
 -   neovim `>= 0.7.0`
--   For Unix systems: `git(1)`, `curl(1)` or `wget(1)`, `unzip(1)`, `tar(1)`, `gzip(1)`
--   For Windows systems: pwsh or powershell, git, tar, and [7zip][7zip] or [peazip][peazip] or [archiver][archiver] or [winzip][winzip] or [WinRAR][winrar]
+-   For Unix systems:
+    -   `git(1)`
+    -   `curl(1)` or `wget(1)`
+    -   `unzip(1)`
+    -   GNU tar (`tar(1)` or `gtar(1)` depending on platform)
+    -   `gzip(1)`
+-   For Windows systems:
+    -   pwsh or powershell
+    -   git
+    -   GNU tar
+    -   One of the following:
+         -   [7zip][7zip]
+         -   [peazip][peazip]
+         -   [archiver][archiver]
+         -   [winzip][winzip]
+         -   [WinRAR][winrar]
 
 Note that `mason.nvim` will regularly shell out to external package managers, such as `cargo` and `npm`. Depending on
 your personal usage, some of these will also need to be installed. Refer to `:checkhealth mason` for a full list.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Packages are installed in Neovim's data directory ([`:h standard-path`][help-sta
 linked to a single `bin/` directory, which `mason.nvim` will add to Neovim's PATH during setup, allowing seamless access
 from Neovim builtins (shell, terminal, etc.) as well as other 3rd party plugins.
 
-For a list of all available packages, see https://mason-registry.dev/registry/list.
+For a list of all available packages, see <https://mason-registry.dev/registry/list>.
 
 ## How to use installed packages
 
@@ -91,11 +91,11 @@ The _minimum_ recommended requirements are:
     -   git
     -   GNU tar
     -   One of the following:
-         -   [7zip][7zip]
-         -   [peazip][peazip]
-         -   [archiver][archiver]
-         -   [winzip][winzip]
-         -   [WinRAR][winrar]
+        -   [7zip][7zip]
+        -   [peazip][peazip]
+        -   [archiver][archiver]
+        -   [winzip][winzip]
+        -   [WinRAR][winrar]
 
 Note that `mason.nvim` will regularly shell out to external package managers, such as `cargo` and `npm`. Depending on
 your personal usage, some of these will also need to be installed. Refer to `:checkhealth mason` for a full list.
@@ -159,7 +159,6 @@ Refer to the [Wiki](https://github.com/williamboman/mason.nvim/wiki/Extensions) 
 -   `:MasonUninstall <package> ...` - uninstalls the provided packages
 -   `:MasonUninstallAll` - uninstalls all packages
 -   `:MasonLog` - opens the `mason.nvim` log file in a new tab window
-
 
 # Registries
 

--- a/lua/mason-core/installer/managers/std.lua
+++ b/lua/mason-core/installer/managers/std.lua
@@ -109,6 +109,20 @@ end
 local function untar(rel_path)
     log.fmt_debug("std: untar %s", rel_path)
     local ctx = installer.context()
+    local tar = vim.fn.executable "gtar" == 1 and "gtar" or "tar"
+    return ctx.spawn[tar]({ "--no-same-owner", "-xvf", rel_path }):on_success(function()
+        pcall(function()
+            ctx.fs:unlink(rel_path)
+        end)
+    end)
+end
+
+---@async
+---@param rel_path string
+---@nodiscard
+function M.untar(rel_path)
+    log.fmt_debug("std: untar %s", rel_path)
+    local ctx = installer.context()
     a.scheduler()
     local tar = vim.fn.executable "gtar" == 1 and "gtar" or "tar"
     return ctx.spawn[tar]({ "--no-same-owner", "-xvf", rel_path }):on_success(function()

--- a/lua/mason-core/installer/managers/std.lua
+++ b/lua/mason-core/installer/managers/std.lua
@@ -109,20 +109,6 @@ end
 local function untar(rel_path)
     log.fmt_debug("std: untar %s", rel_path)
     local ctx = installer.context()
-    local tar = vim.fn.executable "gtar" == 1 and "gtar" or "tar"
-    return ctx.spawn[tar]({ "--no-same-owner", "-xvf", rel_path }):on_success(function()
-        pcall(function()
-            ctx.fs:unlink(rel_path)
-        end)
-    end)
-end
-
----@async
----@param rel_path string
----@nodiscard
-function M.untar(rel_path)
-    log.fmt_debug("std: untar %s", rel_path)
-    local ctx = installer.context()
     a.scheduler()
     local tar = vim.fn.executable "gtar" == 1 and "gtar" or "tar"
     return ctx.spawn[tar]({ "--no-same-owner", "-xvf", rel_path }):on_success(function()

--- a/lua/mason-core/installer/managers/std.lua
+++ b/lua/mason-core/installer/managers/std.lua
@@ -1,5 +1,6 @@
 local Result = require "mason-core.result"
 local _ = require "mason-core.functional"
+local a = require "mason-core.async"
 local fetch = require "mason-core.fetch"
 local installer = require "mason-core.installer"
 local log = require "mason-core.log"
@@ -108,11 +109,9 @@ end
 local function untar(rel_path)
     log.fmt_debug("std: untar %s", rel_path)
     local ctx = installer.context()
-    local tar_cmd = ctx.spawn.tar
-    if platform.is.unix and not platform.is.linux then
-        tar_cmd = ctx.spawn.gtar
-    end
-    return tar_cmd({ "--no-same-owner", "-xvf", rel_path }):on_success(function()
+    a.scheduler()
+    local tar = vim.fn.executable "gtar" == 1 and "gtar" or "tar"
+    return ctx.spawn[tar]({ "--no-same-owner", "-xvf", rel_path }):on_success(function()
         pcall(function()
             ctx.fs:unlink(rel_path)
         end)

--- a/lua/mason-core/installer/managers/std.lua
+++ b/lua/mason-core/installer/managers/std.lua
@@ -108,7 +108,11 @@ end
 local function untar(rel_path)
     log.fmt_debug("std: untar %s", rel_path)
     local ctx = installer.context()
-    return ctx.spawn.tar({ "--no-same-owner", "-xvf", rel_path }):on_success(function()
+    local tar_cmd = ctx.spawn.tar
+    if platform.is.unix and not platform.is.linux then
+        tar_cmd = ctx.spawn.gtar
+    end
+    return tar_cmd({ "--no-same-owner", "-xvf", rel_path }):on_success(function()
         pcall(function()
             ctx.fs:unlink(rel_path)
         end)

--- a/lua/mason-core/managers/std/init.lua
+++ b/lua/mason-core/managers/std/init.lua
@@ -100,11 +100,7 @@ end
 function M.untar(file, opts)
     opts = opts or {}
     local ctx = installer.context()
-    local tar_cmd = ctx.spawn.tar
-    if platform.is.unix and not platform.is.linux then
-        tar_cmd = ctx.spawn.gtar
-    end
-    tar_cmd {
+    ctx.spawn.tar {
         opts.strip_components and { "--strip-components", opts.strip_components } or vim.NIL,
         "--no-same-owner",
         "-xvf",

--- a/lua/mason-core/managers/std/init.lua
+++ b/lua/mason-core/managers/std/init.lua
@@ -100,7 +100,11 @@ end
 function M.untar(file, opts)
     opts = opts or {}
     local ctx = installer.context()
-    ctx.spawn.tar {
+    local tar_cmd = ctx.spawn.tar
+    if platform.is.unix and not platform.is.linux then
+        tar_cmd = ctx.spawn.gtar
+    end
+    tar_cmd {
         opts.strip_components and { "--strip-components", opts.strip_components } or vim.NIL,
         "--no-same-owner",
         "-xvf",

--- a/lua/mason/health.lua
+++ b/lua/mason/health.lua
@@ -143,7 +143,12 @@ local function check_core_utils()
         use_stderr = platform.is.mac, -- Apple gzip prints version string to stderr
         relaxed = platform.is.win,
     }
-    check { cmd = "tar", args = { "--version" }, name = "tar" }
+
+    local tar_cmd = "tar"
+    if platform.is.unix and not platform.is.linux then
+        tar_cmd = "gtar"
+    end
+    check { cmd = tar_cmd, args = { "--version" }, name = tar_cmd }
 
     if platform.is.unix then
         check { cmd = "bash", args = { "--version" }, name = "bash" }

--- a/lua/mason/health.lua
+++ b/lua/mason/health.lua
@@ -144,11 +144,8 @@ local function check_core_utils()
         relaxed = platform.is.win,
     }
 
-    local tar_cmd = "tar"
-    if platform.is.unix and not platform.is.linux then
-        tar_cmd = "gtar"
-    end
-    check { cmd = tar_cmd, args = { "--version" }, name = tar_cmd }
+    local tar = vim.fn.executable "gtar" == 1 and "gtar" or "tar"
+    check { cmd = tar, args = { "--version" }, name = tar }
 
     if platform.is.unix then
         check { cmd = "bash", args = { "--version" }, name = "bash" }

--- a/tests/mason-core/installer/managers/std_spec.lua
+++ b/tests/mason-core/installer/managers/std_spec.lua
@@ -1,15 +1,7 @@
 local installer = require "mason-core.installer"
 local match = require "luassert.match"
-local platform = require "mason-core.platform"
 local std = require "mason-core.installer.managers.std"
 local stub = require "luassert.stub"
-
-local function get_tar_cmd(ctx)
-    if platform.is.unix and not platform.is.linux then
-        return ctx.spawn.gtar
-    end
-    return ctx.spawn.tar
-end
 
 describe("std unpack [Unix]", function()
     it("should unpack .gz", function()
@@ -22,74 +14,76 @@ describe("std unpack [Unix]", function()
         assert.spy(ctx.spawn.gzip).was_called_with { "-d", "file.gz" }
     end)
 
-    it("should unpack .tar", function()
-        local ctx = create_dummy_context()
-        local tar_cmd = get_tar_cmd(ctx)
-        stub(ctx.fs, "unlink")
-        installer.exec_in_context(ctx, function()
-            std.unpack "file.tar"
+    describe("tar (not gtar)", function()
+        before_each(function()
+            stub(vim.fn, "executable")
+            vim.fn.executable.on_call_with("gtar").returns(0)
         end)
 
-        assert.spy(tar_cmd).was_called(1)
-        assert.spy(tar_cmd).was_called_with { "--no-same-owner", "-xvf", "file.tar" }
-        assert.spy(ctx.fs.unlink).was_called(1)
-        assert.spy(ctx.fs.unlink).was_called_with(match.is_ref(ctx.fs), "file.tar")
-    end)
+        it("should unpack .tar", function()
+            local ctx = create_dummy_context()
+            stub(ctx.fs, "unlink")
+            installer.exec_in_context(ctx, function()
+                std.unpack "file.tar"
+            end)
 
-    it("should unpack .tar.bz2", function()
-        local ctx = create_dummy_context()
-        local tar_cmd = get_tar_cmd(ctx)
-        stub(ctx.fs, "unlink")
-        installer.exec_in_context(ctx, function()
-            std.unpack "file.tar.bz2"
+            assert.spy(ctx.spawn.tar).was_called(1)
+            assert.spy(ctx.spawn.tar).was_called_with { "--no-same-owner", "-xvf", "file.tar" }
+            assert.spy(ctx.fs.unlink).was_called(1)
+            assert.spy(ctx.fs.unlink).was_called_with(match.is_ref(ctx.fs), "file.tar")
         end)
 
-        assert.spy(tar_cmd).was_called(1)
-        assert.spy(tar_cmd).was_called_with { "--no-same-owner", "-xvf", "file.tar.bz2" }
-        assert.spy(ctx.fs.unlink).was_called(1)
-        assert.spy(ctx.fs.unlink).was_called_with(match.is_ref(ctx.fs), "file.tar.bz2")
-    end)
+        it("should unpack .tar.bz2", function()
+            local ctx = create_dummy_context()
+            stub(ctx.fs, "unlink")
+            installer.exec_in_context(ctx, function()
+                std.unpack "file.tar.bz2"
+            end)
 
-    it("should unpack .tar.gz", function()
-        local ctx = create_dummy_context()
-        local tar_cmd = get_tar_cmd(ctx)
-        stub(ctx.fs, "unlink")
-        installer.exec_in_context(ctx, function()
-            std.unpack "file.tar.gz"
+            assert.spy(ctx.spawn.tar).was_called(1)
+            assert.spy(ctx.spawn.tar).was_called_with { "--no-same-owner", "-xvf", "file.tar.bz2" }
+            assert.spy(ctx.fs.unlink).was_called(1)
+            assert.spy(ctx.fs.unlink).was_called_with(match.is_ref(ctx.fs), "file.tar.bz2")
         end)
 
-        assert.spy(tar_cmd).was_called(1)
-        assert.spy(tar_cmd).was_called_with { "--no-same-owner", "-xvf", "file.tar.gz" }
-        assert.spy(ctx.fs.unlink).was_called(1)
-        assert.spy(ctx.fs.unlink).was_called_with(match.is_ref(ctx.fs), "file.tar.gz")
-    end)
+        it("should unpack .tar.gz", function()
+            local ctx = create_dummy_context()
+            stub(ctx.fs, "unlink")
+            installer.exec_in_context(ctx, function()
+                std.unpack "file.tar.gz"
+            end)
 
-    it("should unpack .tar.xz", function()
-        local ctx = create_dummy_context()
-        local tar_cmd = get_tar_cmd(ctx)
-        stub(ctx.fs, "unlink")
-        installer.exec_in_context(ctx, function()
-            std.unpack "file.tar.xz"
+            assert.spy(ctx.spawn.tar).was_called(1)
+            assert.spy(ctx.spawn.tar).was_called_with { "--no-same-owner", "-xvf", "file.tar.gz" }
+            assert.spy(ctx.fs.unlink).was_called(1)
+            assert.spy(ctx.fs.unlink).was_called_with(match.is_ref(ctx.fs), "file.tar.gz")
         end)
 
-        assert.spy(tar_cmd).was_called(1)
-        assert.spy(tar_cmd).was_called_with { "--no-same-owner", "-xvf", "file.tar.xz" }
-        assert.spy(ctx.fs.unlink).was_called(1)
-        assert.spy(ctx.fs.unlink).was_called_with(match.is_ref(ctx.fs), "file.tar.xz")
-    end)
+        it("should unpack .tar.xz", function()
+            local ctx = create_dummy_context()
+            stub(ctx.fs, "unlink")
+            installer.exec_in_context(ctx, function()
+                std.unpack "file.tar.xz"
+            end)
 
-    it("should unpack .tar.zst", function()
-        local ctx = create_dummy_context()
-        local tar_cmd = get_tar_cmd(ctx)
-        stub(ctx.fs, "unlink")
-        installer.exec_in_context(ctx, function()
-            std.unpack "file.tar.zst"
+            assert.spy(ctx.spawn.tar).was_called(1)
+            assert.spy(ctx.spawn.tar).was_called_with { "--no-same-owner", "-xvf", "file.tar.xz" }
+            assert.spy(ctx.fs.unlink).was_called(1)
+            assert.spy(ctx.fs.unlink).was_called_with(match.is_ref(ctx.fs), "file.tar.xz")
         end)
 
-        assert.spy(tar_cmd).was_called(1)
-        assert.spy(tar_cmd).was_called_with { "--no-same-owner", "-xvf", "file.tar.zst" }
-        assert.spy(ctx.fs.unlink).was_called(1)
-        assert.spy(ctx.fs.unlink).was_called_with(match.is_ref(ctx.fs), "file.tar.zst")
+        it("should unpack .tar.zst", function()
+            local ctx = create_dummy_context()
+            stub(ctx.fs, "unlink")
+            installer.exec_in_context(ctx, function()
+                std.unpack "file.tar.zst"
+            end)
+
+            assert.spy(ctx.spawn.tar).was_called(1)
+            assert.spy(ctx.spawn.tar).was_called_with { "--no-same-owner", "-xvf", "file.tar.zst" }
+            assert.spy(ctx.fs.unlink).was_called(1)
+            assert.spy(ctx.fs.unlink).was_called_with(match.is_ref(ctx.fs), "file.tar.zst")
+        end)
     end)
 
     it("should unpack .vsix", function()

--- a/tests/mason-core/installer/managers/std_spec.lua
+++ b/tests/mason-core/installer/managers/std_spec.lua
@@ -14,23 +14,24 @@ describe("std unpack [Unix]", function()
         assert.spy(ctx.spawn.gzip).was_called_with { "-d", "file.gz" }
     end)
 
-    it("should use gtar if available", function()
-        local ctx = create_dummy_context()
-        stub(ctx.fs, "unlink")
-        stub(vim.fn, "executable")
-        vim.fn.executable.on_call_with("gtar").returns(1)
-        installer.exec_in_context(ctx, function()
-            std.unpack "file.tar.gz"
-        end)
-
-        assert.spy(ctx.spawn.gtar).was_called(1)
-        assert.spy(ctx.spawn.gtar).was_called_with { "--no-same-owner", "-xvf", "file.tar.gz" }
-    end)
-
-    describe("tar (not gtar)", function()
+    describe("tar", function()
         before_each(function()
             stub(vim.fn, "executable")
             vim.fn.executable.on_call_with("gtar").returns(0)
+        end)
+
+        it("should use gtar if available", function()
+            local ctx = create_dummy_context()
+            stub(ctx.fs, "unlink")
+            stub(vim.fn, "executable")
+            vim.fn.executable.on_call_with("gtar").returns(1)
+
+            installer.exec_in_context(ctx, function()
+                std.unpack "file.tar.gz"
+            end)
+
+            assert.spy(ctx.spawn.gtar).was_called(1)
+            assert.spy(ctx.spawn.gtar).was_called_with { "--no-same-owner", "-xvf", "file.tar.gz" }
         end)
 
         it("should unpack .tar", function()

--- a/tests/mason-core/installer/managers/std_spec.lua
+++ b/tests/mason-core/installer/managers/std_spec.lua
@@ -1,7 +1,15 @@
 local installer = require "mason-core.installer"
 local match = require "luassert.match"
+local platform = require "mason-core.platform"
 local std = require "mason-core.installer.managers.std"
 local stub = require "luassert.stub"
+
+local function get_tar_cmd(ctx)
+    if platform.is.unix and not platform.is.linux then
+        return ctx.spawn.gtar
+    end
+    return ctx.spawn.tar
+end
 
 describe("std unpack [Unix]", function()
     it("should unpack .gz", function()
@@ -16,65 +24,70 @@ describe("std unpack [Unix]", function()
 
     it("should unpack .tar", function()
         local ctx = create_dummy_context()
+        local tar_cmd = get_tar_cmd(ctx)
         stub(ctx.fs, "unlink")
         installer.exec_in_context(ctx, function()
             std.unpack "file.tar"
         end)
 
-        assert.spy(ctx.spawn.tar).was_called(1)
-        assert.spy(ctx.spawn.tar).was_called_with { "--no-same-owner", "-xvf", "file.tar" }
+        assert.spy(tar_cmd).was_called(1)
+        assert.spy(tar_cmd).was_called_with { "--no-same-owner", "-xvf", "file.tar" }
         assert.spy(ctx.fs.unlink).was_called(1)
         assert.spy(ctx.fs.unlink).was_called_with(match.is_ref(ctx.fs), "file.tar")
     end)
 
     it("should unpack .tar.bz2", function()
         local ctx = create_dummy_context()
+        local tar_cmd = get_tar_cmd(ctx)
         stub(ctx.fs, "unlink")
         installer.exec_in_context(ctx, function()
             std.unpack "file.tar.bz2"
         end)
 
-        assert.spy(ctx.spawn.tar).was_called(1)
-        assert.spy(ctx.spawn.tar).was_called_with { "--no-same-owner", "-xvf", "file.tar.bz2" }
+        assert.spy(tar_cmd).was_called(1)
+        assert.spy(tar_cmd).was_called_with { "--no-same-owner", "-xvf", "file.tar.bz2" }
         assert.spy(ctx.fs.unlink).was_called(1)
         assert.spy(ctx.fs.unlink).was_called_with(match.is_ref(ctx.fs), "file.tar.bz2")
     end)
 
     it("should unpack .tar.gz", function()
         local ctx = create_dummy_context()
+        local tar_cmd = get_tar_cmd(ctx)
         stub(ctx.fs, "unlink")
         installer.exec_in_context(ctx, function()
             std.unpack "file.tar.gz"
         end)
 
-        assert.spy(ctx.spawn.tar).was_called(1)
-        assert.spy(ctx.spawn.tar).was_called_with { "--no-same-owner", "-xvf", "file.tar.gz" }
+        assert.spy(tar_cmd).was_called(1)
+        assert.spy(tar_cmd).was_called_with { "--no-same-owner", "-xvf", "file.tar.gz" }
         assert.spy(ctx.fs.unlink).was_called(1)
         assert.spy(ctx.fs.unlink).was_called_with(match.is_ref(ctx.fs), "file.tar.gz")
     end)
 
     it("should unpack .tar.xz", function()
         local ctx = create_dummy_context()
+        local tar_cmd = get_tar_cmd(ctx)
         stub(ctx.fs, "unlink")
         installer.exec_in_context(ctx, function()
             std.unpack "file.tar.xz"
         end)
 
-        assert.spy(ctx.spawn.tar).was_called(1)
-        assert.spy(ctx.spawn.tar).was_called_with { "--no-same-owner", "-xvf", "file.tar.xz" }
+        assert.spy(tar_cmd).was_called(1)
+        assert.spy(tar_cmd).was_called_with { "--no-same-owner", "-xvf", "file.tar.xz" }
         assert.spy(ctx.fs.unlink).was_called(1)
         assert.spy(ctx.fs.unlink).was_called_with(match.is_ref(ctx.fs), "file.tar.xz")
     end)
 
     it("should unpack .tar.zst", function()
         local ctx = create_dummy_context()
+        local tar_cmd = get_tar_cmd(ctx)
         stub(ctx.fs, "unlink")
         installer.exec_in_context(ctx, function()
             std.unpack "file.tar.zst"
         end)
 
-        assert.spy(ctx.spawn.tar).was_called(1)
-        assert.spy(ctx.spawn.tar).was_called_with { "--no-same-owner", "-xvf", "file.tar.zst" }
+        assert.spy(tar_cmd).was_called(1)
+        assert.spy(tar_cmd).was_called_with { "--no-same-owner", "-xvf", "file.tar.zst" }
         assert.spy(ctx.fs.unlink).was_called(1)
         assert.spy(ctx.fs.unlink).was_called_with(match.is_ref(ctx.fs), "file.tar.zst")
     end)

--- a/tests/mason-core/installer/managers/std_spec.lua
+++ b/tests/mason-core/installer/managers/std_spec.lua
@@ -14,6 +14,19 @@ describe("std unpack [Unix]", function()
         assert.spy(ctx.spawn.gzip).was_called_with { "-d", "file.gz" }
     end)
 
+    it("should use gtar if available", function()
+        local ctx = create_dummy_context()
+        stub(ctx.fs, "unlink")
+        stub(vim.fn, "executable")
+        vim.fn.executable.on_call_with("gtar").returns(1)
+        installer.exec_in_context(ctx, function()
+            std.unpack "file.tar.gz"
+        end)
+
+        assert.spy(ctx.spawn.gtar).was_called(1)
+        assert.spy(ctx.spawn.gtar).was_called_with { "--no-same-owner", "-xvf", "file.tar.gz" }
+    end)
+
     describe("tar (not gtar)", function()
         before_each(function()
             stub(vim.fn, "executable")


### PR DESCRIPTION
Addresses #1415.

These changes are needed because the relevant code currently assumes GNU tar features like automatic decompression and the `--no-same-owner` flag, but doesn't detect and use GNU tar on platforms where it's named gtar. This causes a number of failures.

With these changes, the health check passes and tarballs are correctly unpacked on platforms other than Linux. This fix affects at least OpenBSD, and probably other systems like FreeBSD, NetBSD, DragonFly BSD, etc.

tests(std_spec.lua): add a local function named get_tar_cmd() that returns the correct version of tar to call. Adjust the tests so that they call gtar when appropriate.

docs(README.md): update requirements so that they explicitly state that GNU tar is used. Clean up requirements by placing them in separate bullet points, rather than listing them in one line.