### PR TITLE
fix(registry): reset registries state when setting registries

### DIFF
--- a/lua/mason-registry/sources/init.lua
+++ b/lua/mason-registry/sources/init.lua
@@ -48,6 +48,7 @@ local registries = {}
 
 ---@param registry_ids string[]
 function M.set_registries(registry_ids)
+    registries = {}
     for _, registry in ipairs(registry_ids) do
         local ok, err = pcall(function()
             table.insert(registries, parse(registry))


### PR DESCRIPTION
This should only be called once (during mason.nvim setup), but this fixes potential duplicate registry registration in
cases where it's called > 1 times.
