### PR TITLE
feat: [pip] added venv_args to configuration options

### DIFF
--- a/lua/mason-core/installer/managers/pypi.lua
+++ b/lua/mason-core/installer/managers/pypi.lua
@@ -6,6 +6,7 @@ local installer = require "mason-core.installer"
 local log = require "mason-core.log"
 local path = require "mason-core.path"
 local platform = require "mason-core.platform"
+local settings = require "mason.settings"
 
 local M = {}
 
@@ -16,7 +17,7 @@ local VENV_DIR = "venv"
 local function create_venv(py_executables)
     local ctx = installer.context()
     return Optional.of_nilable(_.find_first(function(executable)
-        return ctx.spawn[executable]({ "-m", "venv", VENV_DIR }):is_success()
+        return ctx.spawn[executable]({ "-m", "venv", settings.current.pip.venv_args, VENV_DIR }):is_success()
     end, py_executables)):ok_or "Failed to create python3 virtual environment."
 end
 

--- a/lua/mason/settings.lua
+++ b/lua/mason/settings.lua
@@ -66,6 +66,13 @@ local DEFAULT_SETTINGS = {
         --
         -- Example: { "--proxy", "https://proxyserver" }
         install_args = {},
+
+        ---@since 1.8.4
+        -- These args will be added to `python -m venv` calls. Note that setting extra args might impact intended behavior
+        -- and is not recommended.
+        --
+        -- Example: { "--system-site-packges", "--symlinks" }
+        venv_args = {},
     },
 
     ui = {


### PR DESCRIPTION
Added the ability to pass arguments to the `venv`-creator

This is especially useful when for example, using `python-language-server` on a Linux based distro that packages pip-packages as system packages (Debian-based, Arch, ...)

By default you do not get access to system-site packages, meaning no LSP-features for those packages, unless you manually install them (again) in the `python-language-server`-venv

Passing the following circumvents all of that, by allowing the venv to access system packages:
```lua
require("mason").setup({
	pip = {
		venv_args = { "--system-site-packages" },
	},
})
```

ref: https://docs.python.org/3/library/venv.html#creating-virtual-environments