### PR TITLE
fix(registry): fix yq usage

### DIFF
--- a/lua/mason-registry/sources/file.lua
+++ b/lua/mason-registry/sources/file.lua
@@ -108,8 +108,7 @@ function FileRegistrySource:install()
                     local yaml_spec = fs.async.read_file(package_file)
                     local spec = vim.json.decode(spawn
                         [yq]({
-                            "-o",
-                            "json",
+                            ".",
                             on_spawn = a.scope(function(_, stdio)
                                 local stdin = stdio[1]
                                 async_uv.write(stdin, yaml_spec)


### PR DESCRIPTION
I get this error message after `:Mason`. It seems that the yq usage is not right. 

```
  Uninstalled registries
  Packages from the following registries are unavailable. Press C to install.
   - local: /home/doot/tmp/mason-registry [uninstalled]
  
  Registry installation failed with the following error:
    FileRegistrySource(path=/home/doot/tmp/mason-registry) failed to install: ...nvim/lazy/mason.nvim/lua/mason-registry/sources/file.lua:128: ...nvim/lazy/mason.nvim/lua/mason-registry/sources/file.lua:120: Failed to parse /home/doot/tmp/mason-registry/packages/erlang-ls/package.yaml.
 ```

After this fix, it works as expected.