### PR TITLE
feat(npm): add install args option

### DIFF
--- a/lua/mason-core/installer/managers/npm.lua
+++ b/lua/mason-core/installer/managers/npm.lua
@@ -5,6 +5,7 @@ local log = require "mason-core.log"
 local path = require "mason-core.path"
 local platform = require "mason-core.platform"
 local semver = require "mason-core.semver"
+local settings = require "mason.settings"
 local spawn = require "mason-core.spawn"
 
 local M = {}
@@ -63,11 +64,11 @@ function M.install(pkg, version, opts)
     log.fmt_debug("npm: install %s %s %s", pkg, version, opts)
     local ctx = installer.context()
     ctx.stdio_sink.stdout(("Installing npm package %s@%s…\n"):format(pkg, version))
-    return ctx.spawn.npm {
+    return ctx.spawn.npm(vim.list_extend({
         "install",
         ("%s@%s"):format(pkg, version),
         opts.extra_packages or vim.NIL,
-    }
+    }, settings.current.npm.install_args))
 end
 
 ---@param exec string

--- a/lua/mason-core/managers/npm/init.lua
+++ b/lua/mason-core/managers/npm/init.lua
@@ -4,6 +4,7 @@ local installer = require "mason-core.installer"
 local path = require "mason-core.path"
 local platform = require "mason-core.platform"
 local providers = require "mason-core.providers"
+local settings = require "mason.settings"
 local spawn = require "mason-core.spawn"
 
 local list_copy = _.list_copy
@@ -63,7 +64,7 @@ function M.install(packages)
     ctx.fs:append_file(".npmrc", "global-style=true")
 
     ensure_npm_root(ctx)
-    ctx.spawn.npm { "install", pkgs }
+    ctx.spawn.npm(vim.list_extend({ "install", pkgs }, settings.current.npm.install_args))
 
     if packages.bin then
         _.each(function(executable)

--- a/lua/mason/settings.lua
+++ b/lua/mason/settings.lua
@@ -68,6 +68,15 @@ local DEFAULT_SETTINGS = {
         install_args = {},
     },
 
+    npm = {
+        ---@since 1.0.0
+        -- These args will be added to `npm install` calls. Note that setting extra args might impact intended behavior
+        -- and is not recommended.
+        --
+        -- Example: { "--registry", "https://registry.npmjs.org/" }
+        install_args = {},
+    },
+
     ui = {
         ---@since 1.0.0
         -- Whether to automatically check for new versions when opening the :Mason window.


### PR DESCRIPTION
Mostly when I'm working, my npm registry is set to the work's registry, which sometimes causes npm installations in mason to fail.

To overcome this I added the option to provide `install_args` to `npm`, same as available in `pip`, so I can override `npm install`s in mason to always use the default npm registry.

I made the change in both places where `npm install` is invoked, `lua/mason-core/managers/npm/init.lua` seems outdated but I wasn't sure whether I should still support it. If not let me know and I can remove it.
