### PR TITLE
feat(ui): remove whitespace in empty lines

### DIFF
--- a/lua/mason-core/ui/display.lua
+++ b/lua/mason-core/ui/display.lua
@@ -119,10 +119,9 @@ local function render_node(viewport_context, node, _render_context, _output)
                 end
             end
 
-            local active_styles = get_styles(full_line, render_context)
-
-            -- apply indentation to non-empty lines
+            -- only apply cascading styles to non-empty lines
             if string.len(full_line) > 0 then
+                local active_styles = get_styles(full_line, render_context)
                 full_line = (" "):rep(active_styles.indentation) .. full_line
                 for j = 1, #line_highlights do
                     local highlight = line_highlights[j]

--- a/lua/mason-core/ui/display.lua
+++ b/lua/mason-core/ui/display.lua
@@ -121,13 +121,15 @@ local function render_node(viewport_context, node, _render_context, _output)
 
             local active_styles = get_styles(full_line, render_context)
 
-            -- apply indentation
-            full_line = (" "):rep(active_styles.indentation) .. full_line
-            for j = 1, #line_highlights do
-                local highlight = line_highlights[j]
-                highlight.col_start = highlight.col_start + active_styles.indentation
-                highlight.col_end = highlight.col_end + active_styles.indentation
-                output.highlights[#output.highlights + 1] = highlight
+            -- apply indentation to non-empty lines
+            if string.len(full_line) > 0 then
+                full_line = (" "):rep(active_styles.indentation) .. full_line
+                for j = 1, #line_highlights do
+                    local highlight = line_highlights[j]
+                    highlight.col_start = highlight.col_start + active_styles.indentation
+                    highlight.col_end = highlight.col_end + active_styles.indentation
+                    output.highlights[#output.highlights + 1] = highlight
+                end
             end
 
             output.lines[#output.lines + 1] = full_line

--- a/tests/mason-core/ui_spec.lua
+++ b/tests/mason-core/ui_spec.lua
@@ -323,4 +323,24 @@ describe("integration test", function()
             )
         end)
     )
+
+    it("should not apply cascading styles to empty lines", function ()
+        local render_output = display._render_node(
+            {
+                win_width = 120,
+            },
+            Ui.CascadingStyleNode({ "INDENT" }, {
+                Ui.HlTextNode {
+                    {
+                        { "Hello World!", "MyHighlightGroup" },
+                    },
+                    {
+                        { "", "" },
+                    },
+                },
+            })
+        )
+
+        assert.same({"  Hello World!", "" }, render_output.lines)
+    end)
 end)

--- a/tests/mason-core/ui_spec.lua
+++ b/tests/mason-core/ui_spec.lua
@@ -324,7 +324,7 @@ describe("integration test", function()
         end)
     )
 
-    it("should not apply cascading styles to empty lines", function ()
+    it("should not apply cascading styles to empty lines", function()
         local render_output = display._render_node(
             {
                 win_width = 120,
@@ -341,6 +341,6 @@ describe("integration test", function()
             })
         )
 
-        assert.same({"  Hello World!", "" }, render_output.lines)
+        assert.same({ "  Hello World!", "" }, render_output.lines)
     end)
 end)


### PR DESCRIPTION
This PR prevents indentation from being added to blank lines in the UI, which in turn allows the user to move between sections using the `}` keybind. Here's an example gif:

![mason_whitespace](https://github.com/williamboman/mason.nvim/assets/87077023/2f9c750f-ea34-410a-9ff0-772676c96341)

Closes #1529 