### PR TITLE
docs: add information that `vim.g.python3_host_prog` is used

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,10 @@ local DEFAULT_SETTINGS = {
 }
 ```
 
+> [!NOTE]
+> mason uses the python version specified via `vim.g.python3_host_prog`. This can be relevant for some packages,
+> where the most recent version requires a more recent python version than the one installed system's default.
+
 ---
 
 <sup>


### PR DESCRIPTION
I recently had some headaches wondering mason was using an outdated python version. The recent version of some packages available via mason require a more recent python, but as mason was using an older python version, they would not be able to be installed.

I figured out that it was using my system's python, and with some research figured out that it is in fact `vim.g.python3_host_prog` that determines which python is used by mason. I think it is worth mentioning in the README that this variable determines what python mason uses. 

(Maybe it could also make sense to have a setting in the mason config to explicitly tell mason which python it should use?)