### PR TITLE
fix(uninstall): fix 'rmdir' failure under Windows

### DIFF
--- a/lua/mason-core/fs.lua
+++ b/lua/mason-core/fs.lua
@@ -49,10 +49,15 @@ local function make_module(uv)
             a.scheduler()
         end
         local uv = vim.uv or vim.loop
-        local success, err = uv.fs_unlink(path)
-        if not success then
+        if string.find(uv.os_uname().sysname, "Windows") then
+            path = path:gsub("/", "\\")
+        end
+        if vim.fn.delete(path, "rf") ~= 0 then
+            -- local success, err = uv.fs_unlink(path)
+            -- if not success then
             log.debug "fs: rmrf failed"
-            error(("rmrf: Could not remove directory %q. error: %s"):format(path, vim.inspect(err)))
+            error(("rmrf: Could not remove directory %q."):format(path))
+            -- error(("rmrf: Could not remove directory %q. error: %s"):format(path, vim.inspect(err)))
         end
     end
 

--- a/lua/mason-core/fs.lua
+++ b/lua/mason-core/fs.lua
@@ -48,9 +48,11 @@ local function make_module(uv)
         if vim.in_fast_event() then
             a.scheduler()
         end
-        if vim.fn.delete(path, "rf") ~= 0 then
+        local uv = vim.uv or vim.loop
+        local success, err = uv.fs_unlink(path)
+        if not success then
             log.debug "fs: rmrf failed"
-            error(("rmrf: Could not remove directory %q."):format(path))
+            error(("rmrf: Could not remove directory %q. error: %s"):format(path, vim.inspect(err)))
         end
     end
 

--- a/vim.yml
+++ b/vim.yml
@@ -80,3 +80,6 @@ globals:
     assert.is_not.has_error:
         args:
             - type: function
+
+
+

--- a/vim.yml
+++ b/vim.yml
@@ -80,6 +80,3 @@ globals:
     assert.is_not.has_error:
         args:
             - type: function
-
-
-


### PR DESCRIPTION
## Problem Statement

> This is a Windows filesystem behavior issue

In Windows, when starting lua-language-server (installed by mason), the windows filesystem will (I'm not sure what terminology I should describe it) lock the package directory on disk, then when you want to uninstall lua-language-server, it will throw an exception:

![image](https://github.com/williamboman/mason.nvim/assets/6496887/3f00a58f-c821-4ed3-812c-60e1c7f60ec8)

The exception is thrown from here: https://github.com/linrongbin16/mason.nvim/blob/98c8792bbeb39c2f25e9970eafbbfab2edcdc6b5/lua/mason-core/fs.lua?plain=1#L51

It's because Windows filesystem is different from UNIX/Linux world. This PR is trying to fix it.

## Re-produce Steps

1. With mason and its default configuration, install lua-language-server with `:Mason<CR>`.
2. Starting it (for example by start editing a nvim lua file).
3. Open mason modal with `:Mason<CR>`.
4. Press `X` to uninstall lua-language-server.

## References

1. https://stackoverflow.com/questions/46020018/error-eperm-operation-not-permitted-unlink-d-sources-node-modules-fseven