### PR TITLE
feat: don't use vim.g.python3_host_prog as a candidate for python

### DIFF
--- a/lua/mason-core/installer/managers/pypi.lua
+++ b/lua/mason-core/installer/managers/pypi.lua
@@ -72,13 +72,7 @@ function M.init(opts)
 
         a.scheduler()
 
-        local executables = platform.is.win
-                and _.list_not_nil(
-                    vim.g.python3_host_prog and vim.fn.expand(vim.g.python3_host_prog),
-                    "python",
-                    "python3"
-                )
-            or _.list_not_nil(vim.g.python3_host_prog and vim.fn.expand(vim.g.python3_host_prog), "python3", "python")
+        local executables = platform.is.win and { "python", "python3" } or { "python3", "python" }
 
         -- pip3 will hardcode the full path to venv executables, so we need to promote cwd to make sure pip uses the final destination path.
         ctx:promote_cwd()

--- a/lua/mason-core/managers/pip3/init.lua
+++ b/lua/mason-core/managers/pip3/init.lua
@@ -48,9 +48,7 @@ function M.install(packages)
 
     a.scheduler()
 
-    local executables = platform.is.win
-            and _.list_not_nil(vim.g.python3_host_prog and vim.fn.expand(vim.g.python3_host_prog), "python", "python3")
-        or _.list_not_nil(vim.g.python3_host_prog and vim.fn.expand(vim.g.python3_host_prog), "python3", "python")
+    local executables = platform.is.win and { "python", "python3" } or { "python3", "python" }
 
     -- pip3 will hardcode the full path to venv executables, so we need to promote cwd to make sure pip uses the final destination path.
     ctx:promote_cwd()

--- a/lua/mason/health.lua
+++ b/lua/mason/health.lua
@@ -280,24 +280,6 @@ local function check_languages()
                 }
             end
         end,
-        function()
-            a.scheduler()
-            if vim.g.python3_host_prog then
-                check {
-                    cmd = vim.fn.expand(vim.g.python3_host_prog),
-                    args = { "--version" },
-                    name = "python3_host_prog",
-                    relaxed = true,
-                }
-                a.scheduler()
-                check {
-                    cmd = vim.fn.expand(vim.g.python3_host_prog),
-                    args = { "-m", "pip", "--version" },
-                    name = "python3_host_prog pip",
-                    relaxed = true,
-                }
-            end
-        end,
     }
 end
 

--- a/tests/mason-core/managers/pip3_spec.lua
+++ b/tests/mason-core/managers/pip3_spec.lua
@@ -63,58 +63,18 @@ describe("pip3 manager", function()
     it(
         "should exhaust python3 executable candidates if all fail",
         async_test(function()
-            vim.g.python3_host_prog = "/my/python3"
             local handle = InstallHandleGenerator "dummy"
             local ctx = InstallContextGenerator(handle)
             ctx.spawn.python3 = spy.new(mockx.throws())
             ctx.spawn.python = spy.new(mockx.throws())
-            ctx.spawn[vim.g.python3_host_prog] = spy.new(mockx.throws())
             local err = assert.has_error(function()
                 installer.prepare_installer(ctx):get_or_throw()
                 installer.exec_in_context(ctx, pip3.packages { "package" })
             end)
-            vim.g.python3_host_prog = nil
 
             assert.equals("Unable to create python3 venv environment.", err)
-            assert.spy(ctx.spawn["/my/python3"]).was_called(1)
             assert.spy(ctx.spawn.python3).was_called(1)
             assert.spy(ctx.spawn.python).was_called(1)
-        end)
-    )
-
-    it(
-        "should not exhaust python3 executable if one succeeds",
-        async_test(function()
-            vim.g.python3_host_prog = "/my/python3"
-            local handle = InstallHandleGenerator "dummy"
-            local ctx = InstallContextGenerator(handle)
-            ctx.spawn.python3 = spy.new(mockx.throws())
-            ctx.spawn.python = spy.new(mockx.returns {})
-            ctx.spawn[vim.g.python3_host_prog] = spy.new(mockx.returns {})
-
-            installer.prepare_installer(ctx):get_or_throw()
-            installer.exec_in_context(ctx, pip3.packages { "package" })
-            vim.g.python3_host_prog = nil
-            assert.spy(ctx.spawn.python3).was_called(0)
-            assert.spy(ctx.spawn.python).was_called(1)
-            assert.spy(ctx.spawn["/my/python3"]).was_called(1)
-        end)
-    )
-
-    it(
-        "should expand python3_host_prog path",
-        async_test(function()
-            vim.g.python3_host_prog = "~/python3"
-            local handle = InstallHandleGenerator "dummy"
-            local ctx = InstallContextGenerator(handle)
-            ctx.spawn.python = spy.new(mockx.returns {})
-            ctx.spawn[vim.env.HOME .. "/python3"] = spy.new(mockx.returns {})
-
-            installer.prepare_installer(ctx):get_or_throw()
-            installer.exec_in_context(ctx, pip3.packages { "package" })
-            a.scheduler()
-            vim.g.python3_host_prog = nil
-            assert.spy(ctx.spawn[vim.env.HOME .. "/python3"]).was_called(1)
         end)
     )
 


### PR DESCRIPTION
This is inconsistent with how other system dependencies are resolved and is not
documented anywhere.
