### PR TITLE
Add setting to hide the UI header

### DIFF
--- a/lua/mason/settings.lua
+++ b/lua/mason/settings.lua
@@ -89,6 +89,9 @@ local DEFAULT_SETTINGS = {
         -- - Float in the range of 0-1 for a percentage of screen height.
         height = 0.9,
 
+        -- Whether to show the header.
+        show_header = true,
+
         icons = {
             ---@since 1.0.0
             -- The list icon to use for installed packages.

--- a/lua/mason/ui/components/header.lua
+++ b/lua/mason/ui/components/header.lua
@@ -6,9 +6,9 @@ local settings = require "mason.settings"
 ---@param state InstallerUiState
 return function(state)
     local uninstalled_registries = _.filter(_.prop_eq("is_installed", false), state.info.registries)
-
-    return Ui.Node {
-        Ui.CascadingStyleNode({ "CENTERED" }, {
+    local header = Ui.EmptyLine()
+    if settings.current.ui.show_header then
+        header = Ui.CascadingStyleNode({ "CENTERED" }, {
             Ui.HlTextNode {
                 Ui.When(state.view.is_showing_help, {
                     p.header_secondary(" " .. state.header.title_prefix .. " mason.nvim "),
@@ -28,7 +28,11 @@ return function(state)
                 }),
                 { p.Comment "https://github.com/williamboman/mason.nvim" },
             },
-        }),
+        })
+    end
+
+    return Ui.Node {
+        header,
         Ui.When(not state.packages.new_versions_check.is_checking and #uninstalled_registries > 0, function()
             return Ui.CascadingStyleNode({ "INDENT" }, {
                 Ui.EmptyLine(),


### PR DESCRIPTION
The header is the following text at the top of the window:

`
                mason.nvim                
            press g? for help             
https://github.com/williamboman/mason.nvim
`

For some, it is a little much. 
Being able to hide it would make it easier to have visual cohesion between other floating popups like Lazy.nvim.

I have added a simple boolean setting 'show_header'.
When it is `true` (the default value), everything acts as it usually does.
When it is `false`, the header is replaced with a single blank line acting as a margin.

It is a very simple setting, and it is my first PR contribution to a public project, so suggestions and corrections are expected.