### PR TITLE
fix(health): support multidigit luarocks version numbers (#1646)

### DIFF
--- a/lua/mason/health.lua
+++ b/lua/mason/health.lua
@@ -210,7 +210,7 @@ local function check_languages()
             name = "luarocks",
             relaxed = true,
             version_check = function(version)
-                local _, _, major = version:find "(%d+)%.(%d)%.(%d)"
+                local _, _, major = version:find "(%d+)%.(%d+)%.(%d+)"
                 if not (tonumber(major) >= 3) then
                     -- Because of usage of "--dev" flag
                     return "Luarocks version must be >= 3.0.0."


### PR DESCRIPTION
As described in #1646, this would fix the current inability for `checkhealth mason` to report luarocks versions with multidigit minor version numbers.