### PR TITLE
fix: opam update before lsp upgrade

### DIFF
--- a/lua/mason-core/installer/managers/opam.lua
+++ b/lua/mason-core/installer/managers/opam.lua
@@ -15,13 +15,20 @@ function M.install(package, version)
     log.fmt_debug("opam: install %s %s", package, version)
     local ctx = installer.context()
     ctx.stdio_sink.stdout(("Installing opam package %s@%s…\n"):format(package, version))
-    return ctx.spawn.opam {
-        "install",
-        "--destdir=.",
-        "--yes",
-        "--verbose",
-        ("%s.%s"):format(package, version),
-    }
+    return Result.try(function(try)
+        try(ctx.spawn.opam {
+            "update",
+            "--yes",
+            "--verbose"
+        })
+        try(ctx.spawn.opam {
+            "install",
+            "--destdir=.",
+            "--yes",
+            "--verbose",
+            ("%s.%s"):format(package, version),
+        })
+    end)
 end
 
 ---@param bin string

--- a/tests/mason-core/installer/managers/opam_spec.lua
+++ b/tests/mason-core/installer/managers/opam_spec.lua
@@ -10,7 +10,12 @@ describe("opam manager", function()
             opam.install("opam-package", "1.0.0")
         end)
 
-        assert.spy(ctx.spawn.opam).was_called(1)
+        assert.spy(ctx.spawn.opam).was_called(2)
+        assert.spy(ctx.spawn.opam).was_called_with {
+            "update",
+            "--yes",
+            "--verbose",
+        }
         assert.spy(ctx.spawn.opam).was_called_with {
             "install",
             "--destdir=.",


### PR DESCRIPTION
Hello 👋

I'm fixing a bug where installing a new version of `ocaml-lsp` would make `opam` complain about not being able to find the new version locally, this is because `opam update` needs to be run first to update the local repositories, so I'm running that command before any installation.