### PR TITLE
Fixed comparison of number with nil error

### DIFF
--- a/lua/mason/health.lua
+++ b/lua/mason/health.lua
@@ -211,7 +211,7 @@ local function check_languages()
             relaxed = true,
             version_check = function(version)
                 local _, _, major = version:find "(%d+)%.(%d+)%.(%d+)"
-                if not (tonumber(major) >= 3) then
+                if tonumber(major) ~= nil and not (tonumber(major) >= 3) then
                     -- Because of usage of "--dev" flag
                     return "Luarocks version must be >= 3.0.0."
                 end


### PR DESCRIPTION
Neovim :checkhealth command would return error "number comparison with nil error". I included a check in the conditional to confirm it is not nil. 