### PR TITLE
(feat): add option to ignore non-installed languages in the healthcheck

### DIFF
--- a/lua/mason/health.lua
+++ b/lua/mason/health.lua
@@ -59,8 +59,12 @@ local function check(opts)
 
         report_ok(("%s: `%s`"):format(opts.name, version or "Ok"))
     end):on_failure(function(err)
-        local report = opts.relaxed and report_warn or report_error
-        report(("%s: not available"):format(opts.name), opts.advice or { tostring(err) })
+        if settings.current.health.ignore[opts.name] then
+            report_ok(("%s: not available (SKIPPED)"):format(opts.name))
+        else
+            local report = opts.relaxed and report_warn or report_error
+            report(("%s: not available"):format(opts.name), opts.advice or { tostring(err) })
+        end
     end)
     permit:forget()
 end

--- a/lua/mason/settings.lua
+++ b/lua/mason/settings.lua
@@ -137,6 +137,10 @@ local DEFAULT_SETTINGS = {
             toggle_help = "g?",
         },
     },
+
+    health = {
+        ignore = {},
+    },
 }
 
 M._DEFAULT_SETTINGS = DEFAULT_SETTINGS


### PR DESCRIPTION
Add option to not show non-installed binaries as a warning