### PR TITLE
feat(pypi): fallback to virtualenv if venv fails

### DIFF
--- a/lua/mason-core/installer/managers/pypi.lua
+++ b/lua/mason-core/installer/managers/pypi.lua
@@ -135,7 +135,11 @@ local function create_venv(pkg)
 
     log.fmt_debug("Found python3 installation version=%s, executable=%s", target.version, target.executable)
     ctx.stdio_sink:stdout "Creating virtual environment…\n"
-    return ctx.spawn[target.executable] { "-m", "venv", "--system-site-packages", VENV_DIR }
+    local result = ctx.spawn[target.executable] { "-m", "venv", "--system-site-packages", VENV_DIR }
+    if result.is_success(result) then
+        return result
+    end
+    return ctx.spawn[target.executable] { "-m", "virtualenv", "--system-site-packages", VENV_DIR }
 end
 
 ---@param ctx InstallContext


### PR DESCRIPTION
On Ubuntu 22.04 when the `python3-venv` package is not installed:

* Importing the `venv` module will succeed.
* Running `python3 -m venv --help` will output help.
* Running `python3 -m venv $VENV_DIR` fails with the following output:

```console
$ python3 -m venv $VENV_DIR
The virtual environment was not created successfully because ensurepip is not
available.  On Debian/Ubuntu systems, you need to install the python3-venv
package using the following command.

    apt install python3.10-venv

You may need to use sudo with that command.  After installing the python3-venv
package, recreate your virtual environment.

Failing command: /root/venv/bin/python3
```

When running in a rootless environment installing the `python3-venv` package is not tenable. However, the `virtualenv` package can be installed via `pip` in the users home directory.

This patch checks the result of `python3 -m venv $VENV_DIR`, if that fails then it will fallback to calling `python3 -m virtualenv $VENV_DIR` instead.
