### PR TITLE
fix: avoid calling vim.fn.has inside fast event

### DIFF
--- a/lua/mason-core/functional/type.lua
+++ b/lua/mason-core/functional/type.lua
@@ -11,8 +11,6 @@ _.is = fun.curryN(function(typ, value)
     return type(value) == typ
 end, 2)
 
----@param value any
----@return boolean
-_.is_list = vim.fn.has "nvim-0.10" and vim.islist or vim.tbl_islist
+_.is_list = vim.islist or vim.tbl_islist
 
 return _


### PR DESCRIPTION
When this module is lazily required inside functional/init.lua we may be inside a fast event, causing the module to fail
to load due to the top-level call to vim.fn.has.
