### PR TITLE
fix: remove the package from outdated_packages after uninstalling it

### DIFF
--- a/lua/mason/ui/instance.lua
+++ b/lua/mason/ui/instance.lua
@@ -421,6 +421,9 @@ local function uninstall_package(event)
     ---@type Package
     local pkg = event.payload
     pkg:uninstall()
+    mutate_state(function(state)
+        remove(state.packages.outdated_packages, pkg)
+    end)
     vim.schedule_wrap(notify)(("%q was successfully uninstalled."):format(pkg.name))
 end
 


### PR DESCRIPTION
Remove the package from outdated_packages after uninstalling it. So it won't be reinstalled when updating all packages.

before:

https://github.com/williamboman/mason.nvim/assets/42333826/da84404b-abb8-4ba3-9d50-835f6c414e08


after:

https://github.com/williamboman/mason.nvim/assets/42333826/fd98a38c-174d-45cc-849d-a848db3ba836


