### PR TITLE
fix(pypi): exclude python3.12 from candidate list

### DIFF
--- a/lua/mason-core/installer/managers/pypi.lua
+++ b/lua/mason-core/installer/managers/pypi.lua
@@ -41,7 +41,6 @@ local function get_versioned_candidates(min_version)
             return Optional.empty()
         end
     end, {
-        { semver.new "3.12.0", "python3.12" },
         { semver.new "3.11.0", "python3.11" },
         { semver.new "3.10.0", "python3.10" },
         { semver.new "3.9.0", "python3.9" },

--- a/tests/mason-core/installer/managers/pypi_spec.lua
+++ b/tests/mason-core/installer/managers/pypi_spec.lua
@@ -20,7 +20,7 @@ end
 describe("pypi manager", function()
     before_each(function()
         stub(spawn, "python3", mockx.returns(Result.success()))
-        spawn.python3.on_call_with({ "--version" }).returns(Result.success { stdout = "Python 3.12.0" })
+        spawn.python3.on_call_with({ "--version" }).returns(Result.success { stdout = "Python 3.11.0" })
     end)
 
     it("should init venv without upgrading pip", function()


### PR DESCRIPTION
Support for python3.12 among pypi packages is pretty poor, this limits the upper bound to python3.11 instead.
