### PR TITLE
Make stock python a high priority

### DIFF
--- a/lua/mason-core/installer/managers/pypi.lua
+++ b/lua/mason-core/installer/managers/pypi.lua
@@ -85,8 +85,10 @@ local function create_venv(pkg)
     -- 2. Resolve suitable versioned python3 installation (python3.12, python3.11, etc.).
     local versioned_candidates = {}
     if supported_python_versions ~= nil then
-        log.fmt_debug("Finding versioned candidates for %s", supported_python_versions)
-        versioned_candidates = get_versioned_candidates(supported_python_versions)
+        if stock_target and not pep440_check_version(tostring(stock_target.version), supported_python_versions) then
+            log.fmt_debug("Finding versioned candidates for %s", supported_python_versions)
+            versioned_candidates = get_versioned_candidates(supported_python_versions)
+        end
     end
     local target = resolve_python3(versioned_candidates) or stock_target
 

--- a/tests/mason-core/installer/managers/pypi_spec.lua
+++ b/tests/mason-core/installer/managers/pypi_spec.lua
@@ -179,6 +179,39 @@ describe("pypi manager", function()
         end
     )
 
+    it(
+        "should prioritize stock python",
+        function()
+            local ctx = create_dummy_context { force = true }
+            spy.on(ctx.stdio_sink, "stderr")
+            stub(ctx, "promote_cwd")
+            stub(ctx.fs, "file_exists")
+            stub(providers.pypi, "get_supported_python_versions", mockx.returns(Result.success ">=3.8"))
+            stub(vim.fn, "executable")
+            vim.fn.executable.on_call_with("python3.12").returns(1)
+            stub(spawn, "python3", mockx.returns(Result.success()))
+            spawn.python3.on_call_with({ "--version" }).returns(Result.success { stdout = "Python 3.8.0" })
+
+            installer.exec_in_context(ctx, function()
+                pypi.init {
+                    package = { name = "cmake-language-server", version = "0.1.10" },
+                    upgrade_pip = true,
+                    install_extra_args = { "--proxy", "http://localhost" },
+                }
+            end)
+
+            assert.spy(ctx.promote_cwd).was_called(1)
+            assert.spy(ctx.spawn.python3).was_called(1)
+            assert.spy(ctx.spawn["python3.12"]).was_called(0)
+            assert.spy(ctx.spawn.python3).was_called_with {
+                "-m",
+                "venv",
+                "--system-site-packages",
+                "venv",
+            }
+        end
+    )
+
     it("should install", function()
         local ctx = create_dummy_context()
         stub(ctx.fs, "file_exists")

--- a/tests/mason-core/installer/managers/pypi_spec.lua
+++ b/tests/mason-core/installer/managers/pypi_spec.lua
@@ -179,38 +179,35 @@ describe("pypi manager", function()
         end
     )
 
-    it(
-        "should prioritize stock python",
-        function()
-            local ctx = create_dummy_context { force = true }
-            spy.on(ctx.stdio_sink, "stderr")
-            stub(ctx, "promote_cwd")
-            stub(ctx.fs, "file_exists")
-            stub(providers.pypi, "get_supported_python_versions", mockx.returns(Result.success ">=3.8"))
-            stub(vim.fn, "executable")
-            vim.fn.executable.on_call_with("python3.12").returns(1)
-            stub(spawn, "python3", mockx.returns(Result.success()))
-            spawn.python3.on_call_with({ "--version" }).returns(Result.success { stdout = "Python 3.8.0" })
+    it("should prioritize stock python", function()
+        local ctx = create_dummy_context { force = true }
+        spy.on(ctx.stdio_sink, "stderr")
+        stub(ctx, "promote_cwd")
+        stub(ctx.fs, "file_exists")
+        stub(providers.pypi, "get_supported_python_versions", mockx.returns(Result.success ">=3.8"))
+        stub(vim.fn, "executable")
+        vim.fn.executable.on_call_with("python3.12").returns(1)
+        stub(spawn, "python3", mockx.returns(Result.success()))
+        spawn.python3.on_call_with({ "--version" }).returns(Result.success { stdout = "Python 3.8.0" })
 
-            installer.exec_in_context(ctx, function()
-                pypi.init {
-                    package = { name = "cmake-language-server", version = "0.1.10" },
-                    upgrade_pip = true,
-                    install_extra_args = { "--proxy", "http://localhost" },
-                }
-            end)
-
-            assert.spy(ctx.promote_cwd).was_called(1)
-            assert.spy(ctx.spawn.python3).was_called(1)
-            assert.spy(ctx.spawn["python3.12"]).was_called(0)
-            assert.spy(ctx.spawn.python3).was_called_with {
-                "-m",
-                "venv",
-                "--system-site-packages",
-                "venv",
+        installer.exec_in_context(ctx, function()
+            pypi.init {
+                package = { name = "cmake-language-server", version = "0.1.10" },
+                upgrade_pip = true,
+                install_extra_args = { "--proxy", "http://localhost" },
             }
-        end
-    )
+        end)
+
+        assert.spy(ctx.promote_cwd).was_called(1)
+        assert.spy(ctx.spawn.python3).was_called(1)
+        assert.spy(ctx.spawn["python3.12"]).was_called(0)
+        assert.spy(ctx.spawn.python3).was_called_with {
+            "-m",
+            "venv",
+            "--system-site-packages",
+            "venv",
+        }
+    end)
 
     it("should install", function()
         local ctx = create_dummy_context()


### PR DESCRIPTION
Make stock python a go-to choice rather than specific version if stock python is supported version.

## Rationale
When a user activates a virtual environment, one assumes that all python thingies happen on their virtual environment python, not the system python.

Closes #1748.