### PR TITLE
fix(powershell) convert "Stop" to 'Stop' and a join parameter to single quotes

### DIFF
--- a/lua/mason-core/installer/managers/powershell.lua
+++ b/lua/mason-core/installer/managers/powershell.lua
@@ -8,7 +8,7 @@ local M = {}
 local PWSHOPT = {
     progress_preference = [[ $ProgressPreference = 'SilentlyContinue'; ]], -- https://stackoverflow.com/a/63301751
     security_protocol = [[ [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; ]],
-    error_action_preference = [[ $ErrorActionPreference = "Stop"; ]],
+    error_action_preference = [[ $ErrorActionPreference = 'Stop'; ]],
 }
 
 local powershell = _.lazy(function()

--- a/lua/mason/health.lua
+++ b/lua/mason/health.lua
@@ -114,13 +114,13 @@ local function check_core_utils()
 
     if platform.is.win then
         check {
-            cmd = "pwsh",
+            cmd = (vim.fn.executable "pwsh" == 1 and "pwsh" or "powershell"),
             args = {
                 "-NoProfile",
                 "-Command",
-                [[$PSVersionTable.PSVersion, $PSVersionTable.OS, $PSVersionTable.Platform -join " "]],
+                [[$PSVersionTable.PSVersion, $PSVersionTable.OS, $PSVersionTable.Platform -join ' ']],
             },
-            name = "pwsh",
+            name = (vim.fn.executable "pwsh" == 1 and "pwsh" or "powershell")  -- mason switched back to a powershell default
         }
         check { cmd = "7z", args = { "--help" }, name = "7z", relaxed = true }
     end

--- a/lua/mason/health.lua
+++ b/lua/mason/health.lua
@@ -113,14 +113,15 @@ local function check_core_utils()
     end
 
     if platform.is.win then
+        local powershell = vim.fn.executable "pwsh" == 1 and "pwsh" or "powershell"
         check {
-            cmd = (vim.fn.executable "pwsh" == 1 and "pwsh" or "powershell"),
+            cmd = powershell,
             args = {
                 "-NoProfile",
                 "-Command",
                 [[$PSVersionTable.PSVersion, $PSVersionTable.OS, $PSVersionTable.Platform -join ' ']],
             },
-            name = (vim.fn.executable "pwsh" == 1 and "pwsh" or "powershell")  -- mason switched back to a powershell default
+            name = powershell,
         }
         check { cmd = "7z", args = { "--help" }, name = "7z", relaxed = true }
     end

--- a/tests/mason-core/installer/managers/powershell_spec.lua
+++ b/tests/mason-core/installer/managers/powershell_spec.lua
@@ -69,7 +69,7 @@ describe("powershell manager", function()
             "-NoProfile",
             "-NonInteractive",
             "-Command",
-            [[ $ErrorActionPreference = "Stop";  $ProgressPreference = 'SilentlyContinue';  [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; echo 'Is this bash?']],
+            [[ $ErrorActionPreference = 'Stop';  $ProgressPreference = 'SilentlyContinue';  [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; echo 'Is this bash?']],
         })
     end)
 


### PR DESCRIPTION
Fixes http://github.com/williamboman/mason.nvim/issues/1739

<img width="498" alt="sshot3-fix" src="https://github.com/williamboman/mason.nvim/assets/3280084/105093bc-3b0c-4b7f-8899-f1e28059ec49">

A single-quote was needed to pass the 'Stop' through to `powershell`/`pwsh` correctly.

'SilentlyContinue' was single-quoted while "Stop" was double-quoted.  Converting "Stop" → 'Stop'.