### PR TITLE
feat: add backdrop

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,9 @@ local DEFAULT_SETTINGS = {
         -- The border to use for the UI window. Accepts same border values as |nvim_open_win()|.
         border = "none",
 
+        -- The backdrop opacity. 0 is fully opaque, 100 is fully transparent.
+        backdrop = 100,
+
         ---@since 1.0.0
         -- Width of the window. Accepts:
         -- - Integer greater than 1 for fixed width.

--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ local DEFAULT_SETTINGS = {
         -- The border to use for the UI window. Accepts same border values as |nvim_open_win()|.
         border = "none",
 
+        ---@since 1.11.0
         -- The backdrop opacity. 0 is fully opaque, 100 is fully transparent.
         backdrop = 100,
 

--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ local DEFAULT_SETTINGS = {
 
         ---@since 1.11.0
         -- The backdrop opacity. 0 is fully opaque, 100 is fully transparent.
-        backdrop = 100,
+        backdrop = 60,
 
         ---@since 1.0.0
         -- Width of the window. Accepts:

--- a/doc/mason.txt
+++ b/doc/mason.txt
@@ -331,6 +331,9 @@ Example:
             -- The border to use for the UI window. Accepts same border values as |nvim_open_win()|.
             border = "none",
 
+            -- The backdrop opacity. 0 is fully opaque, 100 is fully transparent.
+            backdrop = 100,
+
             ---@since 1.0.0
             -- Width of the window. Accepts:
             -- - Integer greater than 1 for fixed width.

--- a/doc/mason.txt
+++ b/doc/mason.txt
@@ -333,7 +333,7 @@ Example:
 
             ---@since 1.11.0
             -- The backdrop opacity. 0 is fully opaque, 100 is fully transparent.
-            backdrop = 100,
+            backdrop = 60,
 
             ---@since 1.0.0
             -- Width of the window. Accepts:

--- a/doc/mason.txt
+++ b/doc/mason.txt
@@ -331,6 +331,7 @@ Example:
             -- The border to use for the UI window. Accepts same border values as |nvim_open_win()|.
             border = "none",
 
+            ---@since 1.11.0
             -- The backdrop opacity. 0 is fully opaque, 100 is fully transparent.
             backdrop = 100,
 

--- a/lua/mason-core/ui/display.lua
+++ b/lua/mason-core/ui/display.lua
@@ -382,7 +382,7 @@ function M.new_view_only_win(name, filetype)
         bufnr = vim.api.nvim_create_buf(false, true)
         win_id = vim.api.nvim_open_win(bufnr, true, create_popup_window_opts(window_opts, false))
 
-        local normal_hl = vim.api.nvim_get_hl(0, { name = "Normal" })
+        local normal_hl = vim.api.nvim_get_hl and vim.api.nvim_get_hl(0, { name = "Normal" })
         local is_nvim_transparent = normal_hl and normal_hl.bg == nil
 
         if settings.current.ui.backdrop ~= 100 and vim.o.termguicolors and not is_nvim_transparent then

--- a/lua/mason-core/ui/display.lua
+++ b/lua/mason-core/ui/display.lua
@@ -382,7 +382,10 @@ function M.new_view_only_win(name, filetype)
         bufnr = vim.api.nvim_create_buf(false, true)
         win_id = vim.api.nvim_open_win(bufnr, true, create_popup_window_opts(window_opts, false))
 
-        if settings.current.ui.backdrop ~= 100 then
+        local normal_hl = vim.api.nvim_get_hl(0, { name = "Normal" })
+        local is_nvim_transparent = normal_hl and normal_hl.bg == nil
+
+        if settings.current.ui.backdrop ~= 100 and vim.o.termguicolors and not is_nvim_transparent then
             backdrop_bufnr = vim.api.nvim_create_buf(false, true)
             backdrop_win_id = vim.api.nvim_open_win(backdrop_bufnr, false, create_backdrop_window_opts())
 

--- a/lua/mason/settings.lua
+++ b/lua/mason/settings.lua
@@ -77,6 +77,9 @@ local DEFAULT_SETTINGS = {
         -- The border to use for the UI window. Accepts same border values as |nvim_open_win()|.
         border = "none",
 
+        -- The backdrop opacity. 0 is fully opaque, 100 is fully transparent.
+        backdrop = 100,
+
         ---@since 1.0.0
         -- Width of the window. Accepts:
         -- - Integer greater than 1 for fixed width.

--- a/lua/mason/settings.lua
+++ b/lua/mason/settings.lua
@@ -79,7 +79,7 @@ local DEFAULT_SETTINGS = {
 
         ---@since 1.11.0
         -- The backdrop opacity. 0 is fully opaque, 100 is fully transparent.
-        backdrop = 100,
+        backdrop = 60,
 
         ---@since 1.0.0
         -- Width of the window. Accepts:

--- a/lua/mason/settings.lua
+++ b/lua/mason/settings.lua
@@ -77,6 +77,7 @@ local DEFAULT_SETTINGS = {
         -- The border to use for the UI window. Accepts same border values as |nvim_open_win()|.
         border = "none",
 
+        ---@since 1.11.0
         -- The backdrop opacity. 0 is fully opaque, 100 is fully transparent.
         backdrop = 100,
 

--- a/lua/mason/ui/colors.lua
+++ b/lua/mason/ui/colors.lua
@@ -1,4 +1,5 @@
 local hl_groups = {
+    MasonBackdrop = { bg = "#000000", default = true },
     MasonNormal = { link = "NormalFloat", default = true },
     MasonHeader = { bold = true, fg = "#222222", bg = "#DCA561", default = true },
     MasonHeaderSecondary = { bold = true, fg = "#222222", bg = "#56B6C2", default = true },


### PR DESCRIPTION
`Lazy` plugin manager creates a backdrop right behind its main floating window. This helps to draw our attention to the main window. It would be nice if `mason` could adopt this idea.

### Before:
![image](https://github.com/user-attachments/assets/58cd3706-e473-4b1b-ad33-465a900b6e3d)

### After:
![Screenshot from 2024-07-20 20-33-45](https://github.com/user-attachments/assets/2ccd6244-8aa6-4289-bddc-32feeb68f23f)

As you can see, the backdrop brings depth to the main floating window, thus creates a better UI/UX.