### PR TITLE
feat(nuget): add download option to source and implement repository_url

### DIFF
--- a/lua/mason-core/installer/managers/nuget.lua
+++ b/lua/mason-core/installer/managers/nuget.lua
@@ -1,5 +1,6 @@
 local Result = require "mason-core.result"
 local installer = require "mason-core.installer"
+local log = require "mason-core.log"
 local platform = require "mason-core.platform"
 local fetch = require "mason-core.fetch"
 
@@ -11,8 +12,9 @@ local M = {}
 ---@param repository_url string
 ---@nodiscard
 function M.install(package, version, repository_url)
+    log.fmt_debug("nuget: install %s %s", package, version)
     local ctx = installer.context()
-
+    ctx.stdio_sink.stdout(("Installing nuget package %s@%s…\n"):format(package, version))
     local args = {
         "tool",
         "update",

--- a/lua/mason-core/installer/managers/nuget.lua
+++ b/lua/mason-core/installer/managers/nuget.lua
@@ -1,72 +1,16 @@
 local Result = require "mason-core.result"
 local installer = require "mason-core.installer"
-local log = require "mason-core.log"
 local platform = require "mason-core.platform"
 local fetch = require "mason-core.fetch"
-local common = require "mason-core.installer.managers.common"
 
 local M = {}
 
 ---@async
 ---@param package string
 ---@param version string
----@nodiscard
-function M.install(package, version, repository_url)
-    log.fmt_debug("nuget: install %s %s", package, version)
-    local ctx = installer.context()
-
-    local index_file = M.fetch_nuget_endpoint(repository_url):get_or_throw()
-
-    assert(index_file, "nuget index file could not be retrieved")
-
-    local resource = vim.iter(index_file.resources)
-        :find(function (v)
-            return v['@type'] == 'PackageBaseAddress/3.0.0'
-        end)
-
-    assert(resource, "could not get PackageBaseAddress resource from nuget index file")
-
-    local package_base_address = resource["@id"]
-    local package_lowercase = package:lower()
-
-    local nuspec_url = string.format("%s%s/%s/%s.nuspec",
-        package_base_address,
-        package_lowercase,
-        version,
-        package_lowercase)
-
-    assert(nuspec_url, "nuspec url should be set")
-
-    local nuspec_file = M.fetch_nuget_endpoint_xml(nuspec_url):get_or_throw()
-
-    ctx.stdio_sink.stdout(("Installing nuget package %s@%s…\n"):format(package, version))
-
-    local is_dotnet_tool = string.match(nuspec_file, "<packageType%s+name%s*=%s*\"DotnetTool\"%s*/>")
-    if is_dotnet_tool then
-        return M.install_dotnet_tool(package, version, repository_url)
-    else
-        local nupkg_download_url = string.format("%s%s/%s/%s.%s.nupkg",
-            package_base_address,
-            package_lowercase,
-            version,
-            package_lowercase,
-            version)
-
-        local download_item = {
-            download_url = nupkg_download_url,
-            out_file = string.format("%s-%s.nupkg", package, version)
-        }
-
-        return common.download_files(ctx, { download_item })
-    end
-end
-
----@async
----@param package string
----@param version string
 ---@param repository_url string
 ---@nodiscard
-function M.install_dotnet_tool(package, version, repository_url)
+function M.install(package, version, repository_url)
     local ctx = installer.context()
 
     local args = {
@@ -98,17 +42,6 @@ function M.fetch_nuget_endpoint(repository_url)
             Accept = "application/json",
         },
     }):map_catching(vim.json.decode)
-end
-
----@async
----@param repository_url string
----@return Result
-function M.fetch_nuget_endpoint_xml(repository_url)
-    return fetch(repository_url, {
-        headers = {
-            Accept = "application/xml",
-        },
-    })
 end
 
 ---@param bin string

--- a/lua/mason-core/installer/managers/nuget.lua
+++ b/lua/mason-core/installer/managers/nuget.lua
@@ -9,18 +9,26 @@ local M = {}
 ---@param package string
 ---@param version string
 ---@nodiscard
-function M.install(package, version)
+function M.install(package, version, repository_url)
     log.fmt_debug("nuget: install %s %s", package, version)
     local ctx = installer.context()
     ctx.stdio_sink.stdout(("Installing nuget package %s@%s…\n"):format(package, version))
-    return ctx.spawn.dotnet {
+
+    local args = {
         "tool",
         "update",
         "--tool-path",
         ".",
         { "--version", version },
-        package,
     }
+
+    if repository_url then
+        table.insert(args, { "--add-source",  repository_url })
+    end
+
+    table.insert(args, package)
+
+    return ctx.spawn.dotnet(args)
 end
 
 ---@param bin string

--- a/lua/mason-core/installer/managers/nuget.lua
+++ b/lua/mason-core/installer/managers/nuget.lua
@@ -2,6 +2,8 @@ local Result = require "mason-core.result"
 local installer = require "mason-core.installer"
 local log = require "mason-core.log"
 local platform = require "mason-core.platform"
+local fetch = require "mason-core.fetch"
+local common = require "mason-core.installer.managers.common"
 
 local M = {}
 
@@ -12,23 +14,47 @@ local M = {}
 function M.install(package, version, repository_url)
     log.fmt_debug("nuget: install %s %s", package, version)
     local ctx = installer.context()
+
+    local index_file = M.fetch_nuget_index_file(repository_url):get_or_throw()
+
+    assert(index_file, "nuget index file could not be retrieved")
+
+    local resource = vim.iter(index_file.resources)
+        :find(function (v)
+            return v['@type'] == 'PackageBaseAddress/3.0.0'
+        end)
+
+    assert(resource, "could not get PackageBaseAddress resource from nuget index file")
+
+    local nupkg_download_url = string.format("%s%s/%s/%s.%s.nupkg",
+        resource["@id"],
+        package:lower(),
+        version,
+        package:lower(),
+        version)
+
     ctx.stdio_sink.stdout(("Installing nuget package %s@%s…\n"):format(package, version))
 
-    local args = {
-        "tool",
-        "update",
-        "--tool-path",
-        ".",
-        { "--version", version },
+    local download_item = {
+        download_url = nupkg_download_url,
+        out_file = string.format("%s-%s.nupkg", package, version)
     }
 
-    if repository_url then
-        table.insert(args, { "--add-source",  repository_url })
-    end
+    return common.download_files(ctx, { download_item })
+end
 
-    table.insert(args, package)
+---@alias NugetIndexResource { '@id': string, '@type': string}
+---@alias NugetIndexFile { version: string, resources: NugetIndexResource[]}
 
-    return ctx.spawn.dotnet(args)
+---@async
+---@param repository_url string
+---@return Result # Result<NugetIndexFile>
+function M.fetch_nuget_index_file(repository_url)
+    return fetch(repository_url, {
+        headers = {
+            Accept = "application/json",
+        },
+    }):map_catching(vim.json.decode)
 end
 
 ---@param bin string

--- a/lua/mason-core/installer/managers/std.lua
+++ b/lua/mason-core/installer/managers/std.lua
@@ -224,6 +224,7 @@ local unpack_by_filename = _.cond {
     { _.matches "%.tar%.zst$", untar_zst },
     { _.matches "%.zip$", unzip },
     { _.matches "%.vsix$", unzip },
+    { _.matches "%.nupkg$", unzip },
     { _.matches "%.gz$", gunzip },
     { _.T, _.compose(Result.success, _.format "%q doesn't need unpacking.") },
 }

--- a/lua/mason-core/installer/registry/providers/nuget.lua
+++ b/lua/mason-core/installer/registry/providers/nuget.lua
@@ -1,14 +1,20 @@
 local Result = require "mason-core.result"
+local _ = require "mason-core.functional"
 
 local M = {}
 
 ---@param source RegistryPackageSource
 ---@param purl Purl
 function M.parse(source, purl)
+
+    local repository_url = _.path({ "qualifiers", "repository_url" }, purl)
+
     ---@class ParsedNugetSource : ParsedPackageSource
+    ---@field repository_url string Custom repository URL to pull from
     local parsed_source = {
         package = purl.name,
         version = purl.version,
+        repository_url = repository_url
     }
 
     return Result.success(parsed_source)
@@ -19,7 +25,7 @@ end
 ---@param source ParsedNugetSource
 function M.install(ctx, source)
     local nuget = require "mason-core.installer.managers.nuget"
-    return nuget.install(source.package, source.version)
+    return nuget.install(source.package, source.version, source.repository_url)
 end
 
 ---@async

--- a/lua/mason-core/installer/registry/providers/nuget.lua
+++ b/lua/mason-core/installer/registry/providers/nuget.lua
@@ -9,6 +9,10 @@ function M.parse(source, purl)
 
     local repository_url = _.path({ "qualifiers", "repository_url" }, purl)
 
+    if not repository_url then
+        repository_url = "https://api.nuget.org/v3/index.json"
+    end
+
     ---@class ParsedNugetSource : ParsedPackageSource
     ---@field repository_url string Custom repository URL to pull from
     local parsed_source = {

--- a/lua/mason-core/installer/registry/providers/nuget.lua
+++ b/lua/mason-core/installer/registry/providers/nuget.lua
@@ -1,35 +1,83 @@
 local Result = require "mason-core.result"
+local common = require "mason-core.installer.managers.common"
+local util = require "mason-core.installer.registry.util"
+local expr = require "mason-core.installer.registry.expr"
+local nuget = require "mason-core.installer.managers.nuget"
 local _ = require "mason-core.functional"
 
 local M = {}
 
----@param source RegistryPackageSource
+---@class NugetPackageSource : RegistryPackageSource
+---@field download FileDownloadSpec
+
+---@param source NugetPackageSource
 ---@param purl Purl
 function M.parse(source, purl)
+    return Result.try(function (try)
+        local repository_url = _.path({ "qualifiers", "repository_url" }, purl)
 
-    local repository_url = _.path({ "qualifiers", "repository_url" }, purl)
+        local download_item = nil
+        if source.download then
 
-    if not repository_url then
-        repository_url = "https://api.nuget.org/v3/index.json"
-    end
+            if not repository_url then
+                -- if not set we need to provide repository url because we need it for
+                -- download url discovery
+                repository_url = "https://api.nuget.org/v3/index.json"
+            end
 
-    ---@class ParsedNugetSource : ParsedPackageSource
-    ---@field repository_url string Custom repository URL to pull from
-    local parsed_source = {
-        package = purl.name,
-        version = purl.version,
-        repository_url = repository_url
-    }
+            local index_file = try(nuget.fetch_nuget_endpoint(repository_url))
 
-    return Result.success(parsed_source)
+            local resource = vim.iter(index_file.resources)
+                :find(function (v)
+                    return v['@type'] == 'PackageBaseAddress/3.0.0'
+                end)
+
+            assert(resource, "could not get PackageBaseAddress resource from nuget index file")
+
+            local package_base_address = resource["@id"]
+            local package_lowercase = purl.name:lower()
+
+            local nupkg_download_url = string.format("%s%s/%s/%s.%s.nupkg",
+                package_base_address,
+                package_lowercase,
+                purl.version,
+                package_lowercase,
+                purl.version)
+
+            local expr_ctx = { version = purl.version }
+
+            ---@type FileDownloadSpec
+            local download_spec = try(util.coalesce_by_target(try(expr.tbl_interpolate(source.download, expr_ctx)), {}))
+
+            download_item = {
+                download_url = nupkg_download_url,
+                out_file = download_spec.file
+            }
+        end
+
+        ---@class ParsedNugetSource : ParsedPackageSource
+        ---@field download? DownloadItem
+        ---@field repository_url string Custom repository URL to pull from
+        local parsed_source = {
+            package = purl.name,
+            version = purl.version,
+            download = download_item,
+            repository_url = repository_url
+        }
+
+        return parsed_source
+    end)
 end
 
 ---@async
 ---@param ctx InstallContext
 ---@param source ParsedNugetSource
 function M.install(ctx, source)
-    local nuget = require "mason-core.installer.managers.nuget"
-    return nuget.install(source.package, source.version, source.repository_url)
+    if source.download then
+        return common.download_files(ctx, {source.download})
+    else
+        return nuget.install(source.package, source.version, source.repository_url)
+    end
 end
 
 ---@async

--- a/tests/fixtures/purl-test-suite-data.json
+++ b/tests/fixtures/purl-test-suite-data.json
@@ -157,13 +157,13 @@
   },
   {
     "description": "nuget names are case sensitive",
-    "purl": "pkg:Nuget/EnterpriseLibrary.Common@6.0.1304",
-    "canonical_purl": "pkg:nuget/EnterpriseLibrary.Common@6.0.1304",
+    "purl": "pkg:Nuget/EnterpriseLibrary.Common@6.0.1304?repository_url=https://api.nuget.org/v3/index.json",
+    "canonical_purl": "pkg:nuget/EnterpriseLibrary.Common@6.0.1304?repository_url=https://api.nuget.org/v3/index.json",
     "type": "nuget",
     "namespace": null,
     "name": "EnterpriseLibrary.Common",
     "version": "6.0.1304",
-    "qualifiers": null,
+    "qualifiers": { "repository_url": "https://api.nuget.org/v3/index.json" },
     "subpath": null,
     "is_invalid": false
   },

--- a/tests/mason-core/installer/registry/providers/nuget_spec.lua
+++ b/tests/mason-core/installer/registry/providers/nuget_spec.lua
@@ -6,7 +6,7 @@ local stub = require "luassert.stub"
 
 ---@param overrides Purl
 local function purl(overrides)
-    local purl = Purl.parse("pkg:nuget/package@2.2.0"):get_or_throw()
+    local purl = Purl.parse("pkg:nuget/package@2.2.0?repository_url=https://api.nuget.org/v3/index.json"):get_or_throw()
     if not overrides then
         return purl
     end
@@ -19,6 +19,7 @@ describe("nuget provider :: parsing", function()
             Result.success {
                 package = "package",
                 version = "2.2.0",
+                repository_url = "https://api.nuget.org/v3/index.json"
             },
             nuget.parse({}, purl())
         )
@@ -35,11 +36,12 @@ describe("nuget provider :: installing", function()
             return nuget.install(ctx, {
                 package = "package",
                 version = "1.5.0",
+                repository_url = "https://api.nuget.org/v3/index.json"
             })
         end)
 
         assert.is_true(result:is_success())
         assert.spy(manager.install).was_called(1)
-        assert.spy(manager.install).was_called_with("package", "1.5.0")
+        assert.spy(manager.install).was_called_with("package", "1.5.0", "https://api.nuget.org/v3/index.json")
     end)
 end)


### PR DESCRIPTION
Hi,

A little bit of context for the PR:

I was looking into a way to be able to install a "regular" nuget package to be able to install the official roslyn LSP from Microsoft which is not hosted on nuget.org (for details see https://github.com/dotnet/roslyn/issues/71474#issuecomment-2177303207).

The way currently nuget install works is we use "dotnet tool" to install nuget packages, but this works only with nuget packages which are "tools nuget packages" which means they have a specific structure and are for that also marked as tools in nuget repositories. When you try to install "regular" nuget packages via "dotnet tool" cli, it fails because the structure of the package is a different and it expect it to be formatted as a tool.

In this PR I introduced two things that allow us to install any nuget package if the "package" author decides to do that:

- possibility to describe we want only download the nuget package as is and extract it (because nupkg are just zip files)
- possibility to provide an alternative "repository_url" in the packages purl (which I implemented to work with dotnet tool and the new download way)

After this PR we should be able to do this PR (https://github.com/mason-org/mason-registry/pull/6330) for roslyn LSP in a more convenient way and more importantly to use the origin source for the LSP from the roslyn team.

This is my first PR here so please feel free to comment what I can improve or change.

PS: if possible we should squash the PR, because some commits where for a different solution initially which I abandoned when I came up with the current solution, but I thought it maybe helpful to keep it in the PR history.