### PR TITLE
Fix/1780 more robust fs

### DIFF
--- a/lua/mason-core/fs.lua
+++ b/lua/mason-core/fs.lua
@@ -135,9 +135,11 @@ local function make_module(uv)
             if entries and #entries > 0 then
                 for i = 1, #entries do
                     if entries[i].name and not entries[i].type then
-                        local stat = uv.fs_stat(path .. "/" .. entries[i].name)
+                        -- See https://github.com/luvit/luv/issues/660
+                        local full_path = Path.concat { path, entries[i].name }
+                        log.trace("fs: fs_readdir falling back to fs_stat to find type", full_path)
+                        local stat = uv.fs_stat(full_path)
                         entries[i].type = stat.type
-                        log.trace("fs: using fs_stat to find type of ", path, stat.type)
                     end
                     all_entries[#all_entries + 1] = entries[i]
                 end

--- a/lua/mason-core/fs.lua
+++ b/lua/mason-core/fs.lua
@@ -137,6 +137,7 @@ local function make_module(uv)
                     if entries[i].name and not entries[i].type then
                         local stat = uv.fs_stat(path .. "/" .. entries[i].name)
                         entries[i].type = stat.type
+                        log.trace("fs: using fs_stat to find type of ", path, stat.type)
                     end
                     all_entries[#all_entries + 1] = entries[i]
                 end

--- a/lua/mason-core/fs.lua
+++ b/lua/mason-core/fs.lua
@@ -134,6 +134,10 @@ local function make_module(uv)
             log.trace("fs: fs_readdir", path, entries)
             if entries and #entries > 0 then
                 for i = 1, #entries do
+                    if entries[i].name and not entries[i].type then
+                        local stat = uv.fs_stat(path .. "/" .. entries[i].name)
+                        entries[i].type = stat.type
+                    end
                     all_entries[#all_entries + 1] = entries[i]
                 end
             else


### PR DESCRIPTION
This pull request aims to fix this issue #1780. This issue is create by the libuv that sometimes can return nil type, therefore breaking the directory filter after a fs_readdir in the mason file system wrapper. To mitigate that I used the same fix as in [this issue](https://github.com/luvit/luv/issues/660) and use the fs_stat function if the type is not find by the fs_readdir function.