### PR TITLE
Fixed deprecated calls of vim.validate

### DIFF
--- a/lua/mason-core/package/init.lua
+++ b/lua/mason-core/package/init.lua
@@ -88,26 +88,22 @@ local PackageMt = { __index = Package }
 ---@param spec PackageSpec | RegistryPackageSpec
 function Package.new(spec)
     if is_registry_spec(spec) then
-        vim.validate {
-            name = { spec.name, "s" },
-            description = { spec.description, "s" },
-            homepage = { spec.homepage, "s" },
-            licenses = { spec.licenses, "t" },
-            categories = { spec.categories, "t" },
-            languages = { spec.languages, "t" },
-            source = { spec.source, "t" },
-            bin = { spec.bin, { "t", "nil" } },
-            share = { spec.share, { "t", "nil" } },
-        }
+        vim.validate("name", spec.name, "string")
+        vim.validate("description", spec.description, "string")
+        vim.validate("homepage", spec.homepage, "string")
+        vim.validate("licenses", spec.licenses, "table")
+        vim.validate("categories", spec.categories, "table")
+        vim.validate("languages", spec.languages, "table")
+        vim.validate("source", spec.source, "table")
+        vim.validate("bin", spec.bin, { "table", "nil" })
+        vim.validate("share", spec.share, { "table", "nil" })
     else
-        vim.validate {
-            name = { spec.name, "s" },
-            desc = { spec.desc, "s" },
-            homepage = { spec.homepage, "s" },
-            categories = { spec.categories, "t" },
-            languages = { spec.languages, "t" },
-            install = { spec.install, "f" },
-        }
+        vim.validate("name", spec.name, "string")
+        vim.validate("desc", spec.desc, "string")
+        vim.validate("homepage", spec.homepage, "string")
+        vim.validate("categories", spec.categories, "table")
+        vim.validate("languages", spec.languages, "table")
+        vim.validate("install", spec.install, "function")
     end
 
     return EventEmitter.init(setmetatable({

--- a/lua/mason-core/package/init.lua
+++ b/lua/mason-core/package/init.lua
@@ -87,7 +87,7 @@ local PackageMt = { __index = Package }
 
 ---@param spec PackageSpec | RegistryPackageSpec
 local function validate_spec(spec)
-    if vim.fn.has("nvim-0.11") ~= 1 then
+    if vim.fn.has "nvim-0.11" ~= 1 then
         return
     end
     if is_registry_spec(spec) then

--- a/lua/mason-core/package/init.lua
+++ b/lua/mason-core/package/init.lua
@@ -86,7 +86,10 @@ local PackageMt = { __index = Package }
 ---@field opt table<string, string>?
 
 ---@param spec PackageSpec | RegistryPackageSpec
-function Package.new(spec)
+local function validate_spec(spec)
+    if vim.fn.has("nvim-0.11") ~= 1 then
+        return
+    end
     if is_registry_spec(spec) then
         vim.validate("name", spec.name, "string")
         vim.validate("description", spec.description, "string")
@@ -105,7 +108,11 @@ function Package.new(spec)
         vim.validate("languages", spec.languages, "table")
         vim.validate("install", spec.install, "function")
     end
+end
 
+---@param spec PackageSpec | RegistryPackageSpec
+function Package.new(spec)
+    validate_spec(spec)
     return EventEmitter.init(setmetatable({
         name = spec.name, -- for convenient access
         spec = spec,

--- a/tests/mason-core/package/package_spec.lua
+++ b/tests/mason-core/package/package_spec.lua
@@ -23,60 +23,62 @@ describe("package", function()
         assert.same({ "rust-analyzer", "nightly" }, parse "rust-analyzer@nightly")
     end)
 
-    it("should validate spec", function()
-        local valid_spec = {
-            name = "Package name",
-            desc = "Package description",
-            homepage = "https://example.com",
-            categories = { Pkg.Cat.LSP },
-            languages = { Pkg.Lang.Rust },
-            install = function() end,
-        }
-        local function spec(fields)
-            return setmetatable(fields, { __index = valid_spec })
-        end
-        assert.equals(
-            "name: expected string, got number",
-            assert.has_error(function()
-                Pkg.new(spec { name = 23 })
-            end)
-        )
+    if vim.fn.has "nvim-0.11" == 1 then
+        it("should validate spec", function()
+            local valid_spec = {
+                name = "Package name",
+                desc = "Package description",
+                homepage = "https://example.com",
+                categories = { Pkg.Cat.LSP },
+                languages = { Pkg.Lang.Rust },
+                install = function() end,
+            }
+            local function spec(fields)
+                return setmetatable(fields, { __index = valid_spec })
+            end
+            assert.equals(
+                "name: expected string, got number",
+                assert.has_error(function()
+                    Pkg.new(spec { name = 23 })
+                end)
+            )
 
-        assert.equals(
-            "desc: expected string, got number",
-            assert.has_error(function()
-                Pkg.new(spec { desc = 23 })
-            end)
-        )
+            assert.equals(
+                "desc: expected string, got number",
+                assert.has_error(function()
+                    Pkg.new(spec { desc = 23 })
+                end)
+            )
 
-        assert.equals(
-            "homepage: expected string, got number",
-            assert.has_error(function()
-                Pkg.new(spec { homepage = 23 })
-            end)
-        )
+            assert.equals(
+                "homepage: expected string, got number",
+                assert.has_error(function()
+                    Pkg.new(spec { homepage = 23 })
+                end)
+            )
 
-        assert.equals(
-            "categories: expected table, got number",
-            assert.has_error(function()
-                Pkg.new(spec { categories = 23 })
-            end)
-        )
+            assert.equals(
+                "categories: expected table, got number",
+                assert.has_error(function()
+                    Pkg.new(spec { categories = 23 })
+                end)
+            )
 
-        assert.equals(
-            "languages: expected table, got number",
-            assert.has_error(function()
-                Pkg.new(spec { languages = 23 })
-            end)
-        )
+            assert.equals(
+                "languages: expected table, got number",
+                assert.has_error(function()
+                    Pkg.new(spec { languages = 23 })
+                end)
+            )
 
-        assert.equals(
-            "install: expected function, got number",
-            assert.has_error(function()
-                Pkg.new(spec { install = 23 })
-            end)
-        )
-    end)
+            assert.equals(
+                "install: expected function, got number",
+                assert.has_error(function()
+                    Pkg.new(spec { install = 23 })
+                end)
+            )
+        end)
+    end
 
     it("should create new handle", function()
         local dummy = registry.get_package "dummy"


### PR DESCRIPTION
Hello, this is a simple PR to change the way `vim.validate` is called because of a deprecation in Neovim

This closes https://github.com/williamboman/mason.nvim/issues/1875