### PR TITLE
Install ruby binaries with `--env-shebang`

### DIFF
--- a/lua/mason-core/installer/managers/gem.lua
+++ b/lua/mason-core/installer/managers/gem.lua
@@ -20,6 +20,7 @@ function M.install(pkg, version, opts)
         "install",
         "--no-user-install",
         "--no-format-executable",
+        "--env-shebang",
         "--install-dir=.",
         "--bindir=bin",
         "--no-document",

--- a/tests/mason-core/managers/gem_spec.lua
+++ b/tests/mason-core/managers/gem_spec.lua
@@ -22,6 +22,7 @@ describe("gem manager", function()
                 "install",
                 "--no-user-install",
                 "--no-format-executable",
+                "--env-shebang",
                 "--install-dir=.",
                 "--bindir=bin",
                 "--no-document",


### PR DESCRIPTION
Using nvim on different projects with different ruby versions is made harder when I have to go to the Mason installed binaries and update the shebang so the formatter/lsp/whatever works across ruby versions.

Passing the `--env-shebang` options allows me to run the package using the currently enabled ruby versions.

