### PR TITLE
fix(installer): update cwd after uv_fs_rename() was successful

### DIFF
--- a/lua/mason-core/installer/context/init.lua
+++ b/lua/mason-core/installer/context/init.lua
@@ -86,19 +86,19 @@ function InstallContext:promote_cwd()
     -- 2. Prepare for renaming cwd to destination
     if platform.is.unix then
         -- Some Unix systems will raise an error when renaming a directory to a destination that does not already exist.
-        fs.async.mkdir(install_path)
+        fs.sync.mkdir(install_path)
     end
-    -- 3. Update cwd
-    self.cwd:set(install_path)
-    -- 4. Move the cwd to the final installation directory
-    local rename_success, rename_err = pcall(fs.async.rename, cwd, install_path)
+    -- 3. Move the cwd to the final installation directory
+    local rename_success, rename_err = pcall(fs.sync.rename, cwd, install_path)
     if not rename_success then
         -- On some file systems, we cannot create the directory before renaming. Therefore, remove it and then rename.
         log.trace("Call to uv_fs_rename() while promoting cwd failed.", rename_err)
-        fs.async.rmdir(install_path)
-        assert(fs.async.dir_exists(cwd), "Current working directory no longer exists after retrying uv_fs_rename().")
-        fs.async.rename(cwd, install_path)
+        fs.sync.rmdir(install_path)
+        assert(fs.sync.dir_exists(cwd), "Current working directory no longer exists after retrying uv_fs_rename().")
+        fs.sync.rename(cwd, install_path)
     end
+    -- 4. Update cwd
+    self.cwd:set(install_path)
 end
 
 ---@param rel_path string The relative path from the current working directory to change cwd to. Will only restore to the initial cwd after execution of fn (if provided).


### PR DESCRIPTION
Also moves to fs.sync calls over fs.async to avoid unnecessary async
coroutine overhead.
