### PR TITLE
Avoid crash by adding args to sh cmd

### DIFF
--- a/lua/mason/health.lua
+++ b/lua/mason/health.lua
@@ -110,7 +110,7 @@ local function check_core_utils()
 
     if platform.is.unix then
         check { cmd = "bash", args = { "--version" }, name = "bash" }
-        check { cmd = "sh", name = "sh" }
+        check { cmd = "sh", args = { "-v" }, name = "sh" }
     end
 
     if platform.is.win then


### PR DESCRIPTION
Fix #1982 

Add an argument to the sh check command to prevent crashes during the `:healthcheck`.