### PR TITLE
chore(health): remove sh healthcheck

### DIFF
--- a/lua/mason/health.lua
+++ b/lua/mason/health.lua
@@ -110,7 +110,6 @@ local function check_core_utils()
 
     if platform.is.unix then
         check { cmd = "bash", args = { "--version" }, name = "bash" }
-        check { cmd = "sh", name = "sh" }
     end
 
     if platform.is.win then


### PR DESCRIPTION
This seems to be causing some issues (#1982), and the bourne shell is
not ever used by mason.nvim, so we're removing the healthcheck.

Closes #1982.