### PR TITLE
fix(strip_prefix/suffix): handle nil cases on prefix/suffix strip

### DIFF
--- a/lua/mason-core/functional/string.lua
+++ b/lua/mason-core/functional/string.lua
@@ -108,6 +108,9 @@ _.trim_end_matches = fun.curryN(function(pattern, str)
 end, 2)
 
 _.strip_prefix = fun.curryN(function(prefix_pattern, str)
+    if str == nil then
+        return str
+    end
     if #prefix_pattern > #str then
         return str
     end
@@ -120,6 +123,9 @@ _.strip_prefix = fun.curryN(function(prefix_pattern, str)
 end, 2)
 
 _.strip_suffix = fun.curryN(function(suffix_pattern, str)
+    if str == nil then
+        return str
+    end
     if #suffix_pattern > #str then
         return str
     end

--- a/tests/mason-core/functional/string_spec.lua
+++ b/tests/mason-core/functional/string_spec.lua
@@ -71,6 +71,7 @@ Ipsum
         assert.equals("long_pattern", _.strip_prefix("long_pattern_here", "long_pattern"))
         assert.equals("", _.strip_prefix("pattern_here", "pattern_here"))
         assert.equals("s", _.strip_prefix("pattern_here", "pattern_heres"))
+        assert.equals(nil, _.strip_prefix("any", nil))
     end)
 
     it("should strip_suffix", function()
@@ -81,5 +82,6 @@ Ipsum
         assert.equals("pattern_here", _.strip_suffix("long_pattern_here", "pattern_here"))
         assert.equals("", _.strip_suffix("pattern_here", "pattern_here"))
         assert.equals("s", _.strip_suffix("pattern_here", "spattern_here"))
+        assert.equals(nil, _.strip_suffix("any", nil))
     end)
 end)


### PR DESCRIPTION
Hi @williamboman, In the current prefix/suffix strip methods, when str is nil several lsp installations crash. Include a null check to avoid checking length of nil values.


[ERROR 20-Apr-26 23:11:02] ...pt/mason.nvim/lua/mason-core/installer/InstallRunner.lua:93: Installation failed for Package(name=delve) error="...core/opt/mason.nvim/lua/mason-core/functional/string.lua:113: attempt to get length of local 'str' (a nil value)"
[ERROR 20-Apr-26 23:11:02] ...pt/mason.nvim/lua/mason-core/installer/InstallRunner.lua:93: Installation failed for Package(name=gopls) error="...core/opt/mason.nvim/lua/mason-core/functional/string.lua:113: attempt to get length of local 'str' (a nil value)"
[ERROR 20-Apr-26 23:11:02] ...pt/mason.nvim/lua/mason-core/installer/InstallRunner.lua:93: Installation failed for Package(name=lua-language-server) error="...core/opt/mason.nvim/lua/mason-core/functional/string.lua:113: attempt to get length of local 'str' (a nil value)"
[ERROR 20-Apr-26 23:11:03] ...pt/mason.nvim/lua/mason-core/installer/InstallRunner.lua:93: Installation failed for Package(name=netcoredbg) error="...core/opt/mason.nvim/lua/mason-core/functional/string.lua:113: attempt to get length of local 'str' (a nil value)"
[ERROR 20-Apr-26 23:11:03] ...pt/mason.nvim/lua/mason-core/installer/InstallRunner.lua:93: Installation failed for Package(name=lemminx) error="...core/opt/mason.nvim/lua/mason-core/functional/string.lua:113: attempt to get length of local 'str' (a nil value)"
[ERROR 20-Apr-26 23:11:04] ...pt/mason.nvim/lua/mason-core/installer/InstallRunner.lua:93: Installation failed for Package(name=rust-analyzer) error="...core/opt/mason.nvim/lua/mason-core/functional/string.lua:113: attempt to get length of local 'str' (a nil value)"
[ERROR 20-Apr-26 23:11:05] ...pt/mason.nvim/lua/mason-core/installer/InstallRunner.lua:93: Installation failed for Package(name=codelldb) error="...core/opt/mason.nvim/lua/mason-core/functional/string.lua:113: attempt to get length of local 'str' (a nil value)"
[ERROR 20-Apr-26 23:11:06] ...pt/mason.nvim/lua/mason-core/installer/InstallRunner.lua:93: Installation failed for Package(name=tombi) error="...core/opt/mason.nvim/lua/mason-core/functional/string.lua:113: attempt to get length of local 'str' (a nil value)"
[ERROR 20-Apr-26 23:11:06] ...pt/mason.nvim/lua/mason-core/installer/InstallRunner.lua:93: Installation failed for Package(name=stylua) error="...core/opt/mason.nvim/lua/mason-core/functional/string.lua:113: attempt to get length of local 'str' (a nil value)"
[ERROR 20-Apr-26 23:11:06] ...pt/mason.nvim/lua/mason-core/installer/InstallRunner.lua:93: Installation failed for Package(name=terraform-ls) error="...core/opt/mason.nvim/lua/mason-core/functional/string.lua:113: attempt to get length of local 'str' (a nil value)"
[ERROR 20-Apr-26 23:11:09] ...pt/mason.nvim/lua/mason-core/installer/InstallRunner.lua:93: Installation failed for Package(name=powershell-editor-services) error="...core/opt/mason.nvim/lua/mason-core/functional/string.lua:113: attempt to get length of local 'str' (a nil value)"
[INFO  20-Apr-26 23:17:01] ...pt/mason.nvim/lua/mason-core/installer/InstallRunner.lua:40: Executing installer for Package(name=codelldb) {
